### PR TITLE
Compare network protocol strings regardless of the case

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
@@ -163,7 +164,8 @@ func SvcEngineGet(spdkClient *spdkclient.Client, name string) (res *spdkrpc.Engi
 		return nil, fmt.Errorf("cannot find the Nvmf subsystem for engine %s", name)
 	}
 	for _, listenAddr := range subsystem.ListenAddresses {
-		if listenAddr.Adrfam != spdktypes.NvmeAddressFamilyIPv4 || listenAddr.Trtype != spdktypes.NvmeTransportTypeTCP {
+		if !strings.EqualFold(string(listenAddr.Adrfam), string(spdktypes.NvmeAddressFamilyIPv4)) ||
+			!strings.EqualFold(string(listenAddr.Trtype), string(spdktypes.NvmeTransportTypeTCP)) {
 			continue
 		}
 		port, err := strconv.Atoi(listenAddr.Trsvcid)
@@ -212,7 +214,8 @@ func SvcEngineGet(spdkClient *spdkclient.Client, name string) (res *spdkrpc.Engi
 			return nil, fmt.Errorf("found a remote base bdev %v that does not contain nvme info", bdevNvme.Name)
 		}
 		nvmeInfo := (*bdevNvme.DriverSpecific.Nvme)[0]
-		if nvmeInfo.Trid.Adrfam != spdktypes.NvmeAddressFamilyIPv4 || nvmeInfo.Trid.Trtype != spdktypes.NvmeTransportTypeTCP {
+		if !strings.EqualFold(string(nvmeInfo.Trid.Adrfam), string(spdktypes.NvmeAddressFamilyIPv4)) ||
+			!strings.EqualFold(string(nvmeInfo.Trid.Trtype), string(spdktypes.NvmeTransportTypeTCP)) {
 			return nil, fmt.Errorf("found a remote base bdev %v that contains invalid address family %s and transport type %s", bdevNvme.Name, nvmeInfo.Trid.Adrfam, nvmeInfo.Trid.Trtype)
 		}
 		replicaName := helperutil.GetNvmeControllerNameFromNamespaceName(bdevNvme.Name)


### PR DESCRIPTION
```
instance-manager-1494adfe8b78d0600225cc3d15923e00:/ # ./spdk/scripts/rpc.py nvmf_get_subsystems
[
  {
    "nqn": "nqn.2014-08.org.nvmexpress.discovery",
    "subtype": "Discovery",
    "listen_addresses": [],
    "allow_any_host": true,
    "hosts": []
  },
  {
    "nqn": "nqn.2023-01.io.longhorn.spdk:pvc-275f46df-7f12-408e-aedf-a434a53b27a3-e-927bd756",
    "subtype": "NVMe",
    "listen_addresses": [
      {
        "transport": "TCP",
        "trtype": "TCP",
        "adrfam": "IPv4",
        "traddr": "10.42.1.30",
        "trsvcid": "20002"
      }
    ],
...
```