### PR TITLE
Improve resilience to spdk_tgt crash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/RoaringBitmap/roaring v1.2.3
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
-	github.com/longhorn/go-spdk-helper v0.0.0-20230614144600-60ea9f38b2eb
+	github.com/longhorn/go-spdk-helper v0.0.0-20230620021725-56fd696a7431
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/net v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -544,8 +544,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/longhorn/go-spdk-helper v0.0.0-20230614144600-60ea9f38b2eb h1:p2OeRwJjVbe6MfdpV33Lw0VhjeMXkunTbiat1gR80hg=
-github.com/longhorn/go-spdk-helper v0.0.0-20230614144600-60ea9f38b2eb/go.mod h1:XoGXOYHw1KW3qdvTSimwY+Anyg5cPl6EVkjXxS25Upg=
+github.com/longhorn/go-spdk-helper v0.0.0-20230620021725-56fd696a7431 h1:LbHR6kVmymOB+4cJ5fu30ikZ16+QCZh7MgzZU9e2+Ks=
+github.com/longhorn/go-spdk-helper v0.0.0-20230620021725-56fd696a7431/go.mod h1:XoGXOYHw1KW3qdvTSimwY+Anyg5cPl6EVkjXxS25Upg=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
 github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=

--- a/pkg/spdk/disk.go
+++ b/pkg/spdk/disk.go
@@ -114,12 +114,12 @@ func svcDiskGet(spdkClient *SPDKClient, diskName string) (ret *spdkrpc.Disk, err
 		"diskName": diskName,
 	})
 
-	log.Info("Getting disk info")
+	log.Trace("Getting disk info")
 	defer func() {
 		if err != nil {
 			log.WithError(err).Error("Failed to get disk info")
 		} else {
-			log.Info("Got disk info")
+			log.Trace("Got disk info")
 		}
 	}()
 

--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -859,3 +859,21 @@ func (e *Engine) replicaSnapshotOperation(replicaName, snapshotName, snapshotOp 
 		return fmt.Errorf("unknown replica snapshot operation %s", snapshotOp)
 	}
 }
+
+func (e *Engine) SetErrorState() {
+	needUpdate := false
+
+	e.Lock()
+	defer func() {
+		e.Unlock()
+
+		if needUpdate {
+			e.UpdateCh <- nil
+		}
+	}()
+
+	if e.State != types.InstanceStateStopped && e.State != types.InstanceStateError {
+		e.State = types.InstanceStateError
+		needUpdate = true
+	}
+}

--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -1065,3 +1065,21 @@ func (r *Replica) RebuildingDstSnapshotCreate(spdkClient *SPDKClient, snapshotNa
 
 	return nil
 }
+
+func (r *Replica) SetErrorState() {
+	needUpdate := false
+
+	r.Lock()
+	defer func() {
+		r.Unlock()
+
+		if needUpdate {
+			r.UpdateCh <- nil
+		}
+	}()
+
+	if r.State != types.InstanceStateStopped && r.State != types.InstanceStateError {
+		r.State = types.InstanceStateError
+		needUpdate = true
+	}
+}

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/jsonrpc/types.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/jsonrpc/types.go
@@ -2,6 +2,7 @@ package jsonrpc
 
 import (
 	"fmt"
+	"strings"
 )
 
 type Message struct {
@@ -81,4 +82,13 @@ func IsJSONRPCRespErrorFileExists(err error) bool {
 	}
 
 	return responseError.Code == RespErrorCodeNoFileExists
+}
+
+func IsJSONRPCRespErrorBrokenPipe(err error) bool {
+	jsonRPCError, ok := err.(JSONClientError)
+	if !ok {
+		return false
+	}
+	_, ok = jsonRPCError.ErrorDetail.(*ResponseError)
+	return !ok && strings.Contains(jsonRPCError.ErrorDetail.Error(), "broken pipe")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,7 +23,7 @@ github.com/google/uuid
 # github.com/kr/text v0.1.0
 ## explicit
 github.com/kr/text
-# github.com/longhorn/go-spdk-helper v0.0.0-20230614144600-60ea9f38b2eb
+# github.com/longhorn/go-spdk-helper v0.0.0-20230620021725-56fd696a7431
 ## explicit; go 1.17
 github.com/longhorn/go-spdk-helper/pkg/jsonrpc
 github.com/longhorn/go-spdk-helper/pkg/nvme


### PR DESCRIPTION
 - Mark non-stopped and non-error replicas and engines as error when spdk_tgt is down 
    When the spdk_tgt is somehow down, the replicas and engines are out of sync, need to mark non-stopped and non-error replicas and engines as error. Then, longhorn-manager can be aware of the failed replicas and engines and clean them up.

- Restart spdk_tgt and reconnect to it if it is somehow down

longhorn/longhorn#6071
longhorn/longhorn#6155