### PR TITLE
Blindly stop raid bdev exposure before exposing it

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/longhorn/go-spdk-helper/pkg/jsonrpc"
@@ -173,6 +174,12 @@ func (e *Engine) handleFrontend(spdkClient *spdkclient.Client, portCount int32, 
 	}
 
 	nqn := helpertypes.GetNQN(e.Name)
+
+	e.log.Infof("Blindly stopping expose bdev for engine")
+	if err := spdkClient.StopExposeBdev(nqn); err != nil {
+		return errors.Wrap(err, "failed to stop expose bdev for engine")
+	}
+
 	port, _, err := superiorPortAllocator.AllocateRange(portCount)
 	if err != nil {
 		return err


### PR DESCRIPTION
In some failed cases, SPDK engine raises an error `nvmf ... subsystem already exists` while attempting to create a new subsystem for a RAID bdev. This is due to orphaned resources remaining undeleted after encountering an error.

To prevent this error message, we can blindly stop raid bdev exposure for cleaning up the orphaned resources before exposing it.

longhorn/longhorn#7324