### PR TITLE
Correct the naming of v2 volume snapshot created after backup restoration.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.4.0
 	github.com/longhorn/backupstore v0.0.0-20231229024807-ccb82ae17a0e
 	github.com/longhorn/go-common-libs v0.0.0-20240103081802-3993c5908447
-	github.com/longhorn/go-spdk-helper v0.0.0-20240103085800-6ac35f37b3a7
+	github.com/longhorn/go-spdk-helper v0.0.0-20240107081652-89d49f81392b
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	go.uber.org/multierr v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/longhorn/backupstore v0.0.0-20231229024807-ccb82ae17a0e h1:JuR7tTd4lX
 github.com/longhorn/backupstore v0.0.0-20231229024807-ccb82ae17a0e/go.mod h1:4cbJWtlrD2cGTQxQLtdlPTYopiJiusXH7CpOBrn/s3k=
 github.com/longhorn/go-common-libs v0.0.0-20240103081802-3993c5908447 h1:NwR+xCGLpAORmB1UwNfDkQj3vPNIVikJe/hZe9+BQe0=
 github.com/longhorn/go-common-libs v0.0.0-20240103081802-3993c5908447/go.mod h1:nIECQARppamt2zwFSdzADRTVKo/7izFwWIS3VWi7D/s=
-github.com/longhorn/go-spdk-helper v0.0.0-20240103085800-6ac35f37b3a7 h1:xfJN+zZ+giI65qy6jgMdzwuF1kQHEFYPL5wTQTzgE3c=
-github.com/longhorn/go-spdk-helper v0.0.0-20240103085800-6ac35f37b3a7/go.mod h1:9nZ5HbwviggK6l792X4l9fTivEWmiK3sXFaroiRp2yw=
+github.com/longhorn/go-spdk-helper v0.0.0-20240107081652-89d49f81392b h1:t6Rr7YzYwJFQ05X97wcRqT1CJYarKqtVNL/nTJxuKwQ=
+github.com/longhorn/go-spdk-helper v0.0.0-20240107081652-89d49f81392b/go.mod h1:9nZ5HbwviggK6l792X4l9fTivEWmiK3sXFaroiRp2yw=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/util/device.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/util/device.go
@@ -185,7 +185,7 @@ func parseNumber(str string) (int, error) {
 // GetDeviceSectorSize returns the sector size of the given device
 func GetDeviceSectorSize(devPath string, executor *commonNs.Executor) (int64, error) {
 	opts := []string{
-		"--getsize", devPath,
+		"--getsz", devPath,
 	}
 
 	output, err := executor.Execute(BlockdevBinary, opts, types.ExecuteTimeout)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -64,7 +64,7 @@ github.com/longhorn/go-common-libs/sync
 github.com/longhorn/go-common-libs/sys
 github.com/longhorn/go-common-libs/types
 github.com/longhorn/go-common-libs/utils
-# github.com/longhorn/go-spdk-helper v0.0.0-20240103085800-6ac35f37b3a7
+# github.com/longhorn/go-spdk-helper v0.0.0-20240107081652-89d49f81392b
 ## explicit; go 1.21
 github.com/longhorn/go-spdk-helper/pkg/jsonrpc
 github.com/longhorn/go-spdk-helper/pkg/nvme


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7577

#### What this PR does / why we need it:

Correct the naming of v2 volume snapshot created after backup restoration.
The wrong naming of snapshots leads to the unexpected snapshot deletion.

#### Special notes for your reviewer:

#### Additional documentation or context
