### PR TITLE
Skip validation if dm device is busy and broken

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.4.0
 	github.com/longhorn/backupstore v0.0.0-20240110081942-bd231cfb0c7b
 	github.com/longhorn/go-common-libs v0.0.0-20240103081802-3993c5908447
-	github.com/longhorn/go-spdk-helper v0.0.0-20240110163551-cb9ab0f98d4b
+	github.com/longhorn/go-spdk-helper v0.0.0-20240111043333-3afa7627b1aa
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	go.uber.org/multierr v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/longhorn/backupstore v0.0.0-20240110081942-bd231cfb0c7b h1:euBbfDb6bn
 github.com/longhorn/backupstore v0.0.0-20240110081942-bd231cfb0c7b/go.mod h1:4cbJWtlrD2cGTQxQLtdlPTYopiJiusXH7CpOBrn/s3k=
 github.com/longhorn/go-common-libs v0.0.0-20240103081802-3993c5908447 h1:NwR+xCGLpAORmB1UwNfDkQj3vPNIVikJe/hZe9+BQe0=
 github.com/longhorn/go-common-libs v0.0.0-20240103081802-3993c5908447/go.mod h1:nIECQARppamt2zwFSdzADRTVKo/7izFwWIS3VWi7D/s=
-github.com/longhorn/go-spdk-helper v0.0.0-20240110163551-cb9ab0f98d4b h1:rpwO5sGHfXcN9Bd8f5ZKoSBD4HySbQNGVMm8snoM+NI=
-github.com/longhorn/go-spdk-helper v0.0.0-20240110163551-cb9ab0f98d4b/go.mod h1:9nZ5HbwviggK6l792X4l9fTivEWmiK3sXFaroiRp2yw=
+github.com/longhorn/go-spdk-helper v0.0.0-20240111043333-3afa7627b1aa h1:5AflxT58kroRA+DtmeJwSHLliash47JdrRXVTneGp1o=
+github.com/longhorn/go-spdk-helper v0.0.0-20240111043333-3afa7627b1aa/go.mod h1:9nZ5HbwviggK6l792X4l9fTivEWmiK3sXFaroiRp2yw=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=

--- a/pkg/spdk/backup.go
+++ b/pkg/spdk/backup.go
@@ -160,7 +160,7 @@ func (b *Backup) OpenSnapshot(snapshotName, volumeName string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to create NVMe initiator for snapshot lvol bdev %v", lvolName)
 	}
-	if err := initiator.Start(b.IP, strconv.Itoa(int(b.Port)), false); err != nil {
+	if _, err := initiator.Start(b.IP, strconv.Itoa(int(b.Port)), false); err != nil {
 		return errors.Wrapf(err, "failed to start NVMe initiator for snapshot lvol bdev %v", lvolName)
 	}
 	b.initiator = initiator
@@ -225,7 +225,7 @@ func (b *Backup) CloseSnapshot(snapshotName, volumeName string) error {
 	}
 
 	b.log.Info("Stopping NVMe initiator")
-	if err := b.initiator.Stop(false); err != nil {
+	if _, err := b.initiator.Stop(false, true); err != nil {
 		return errors.Wrapf(err, "failed to stop NVMe initiator")
 	}
 

--- a/pkg/spdk/restore.go
+++ b/pkg/spdk/restore.go
@@ -141,7 +141,7 @@ func (r *Restore) OpenVolumeDev(volDevName string) (*os.File, string, error) {
 	if err != nil {
 		return nil, "", errors.Wrapf(err, "failed to create NVMe initiator for lvol bdev %v", lvolName)
 	}
-	if err := initiator.Start(r.ip, strconv.Itoa(int(r.port)), false); err != nil {
+	if _, err := initiator.Start(r.ip, strconv.Itoa(int(r.port)), false); err != nil {
 		return nil, "", errors.Wrapf(err, "failed to start NVMe initiator for lvol bdev %v", lvolName)
 	}
 	r.initiator = initiator
@@ -162,7 +162,7 @@ func (r *Restore) CloseVolumeDev(volDev *os.File) error {
 	}
 
 	r.log.Info("Stopping NVMe initiator")
-	if err := r.initiator.Stop(false); err != nil {
+	if _, err := r.initiator.Stop(false, false); err != nil {
 		return errors.Wrapf(err, "failed to stop NVMe initiator")
 	}
 

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/util/dmsetup.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/util/dmsetup.go
@@ -22,10 +22,19 @@ func DmsetupCreate(dmDeviceName, table string, executor *commonNs.Executor) erro
 }
 
 // DmsetupSuspend suspends the device mapper device with the given name
-func DmsetupSuspend(dmDeviceName string, executor *commonNs.Executor) error {
+func DmsetupSuspend(dmDeviceName string, noflush, nolockfs bool, executor *commonNs.Executor) error {
 	opts := []string{
 		"suspend", dmDeviceName,
 	}
+
+	if noflush {
+		opts = append(opts, "--noflush")
+	}
+
+	if nolockfs {
+		opts = append(opts, "--nolockfs")
+	}
+
 	_, err := executor.Execute(dmsetupBinary, opts, types.ExecuteTimeout)
 	return err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -64,7 +64,7 @@ github.com/longhorn/go-common-libs/sync
 github.com/longhorn/go-common-libs/sys
 github.com/longhorn/go-common-libs/types
 github.com/longhorn/go-common-libs/utils
-# github.com/longhorn/go-spdk-helper v0.0.0-20240110163551-cb9ab0f98d4b
+# github.com/longhorn/go-spdk-helper v0.0.0-20240111043333-3afa7627b1aa
 ## explicit; go 1.21
 github.com/longhorn/go-spdk-helper/pkg/jsonrpc
 github.com/longhorn/go-spdk-helper/pkg/nvme


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7579

#### What this PR does / why we need it:

Skip validation if dm device is busy and broken to avoid the attaching/detaching loop of a volume using by a Pod (without a controller).

#### Special notes for your reviewer:

#### Additional documentation or context

Deps on https://github.com/longhorn/go-spdk-helper/pull/69
