### PR TITLE
Allow to clean up volume-head when reverting to the parent of the volume-head

### DIFF
--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -971,9 +971,6 @@ func (r *Replica) SnapshotRevert(spdkClient *spdkclient.Client, snapshotName str
 	if snapSvcLvol == nil {
 		return nil, fmt.Errorf("cannot revert to a non-existing snapshot %s(%s)", snapshotName, snapLvolName)
 	}
-	if snapSvcLvol.Children[r.Name] != nil {
-		return nil, fmt.Errorf("cannot revert to the same snapshot %s(%s)", snapshotName, snapLvolName)
-	}
 
 	defer func() {
 		if err != nil && r.State != types.InstanceStateError {


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#7630

#### What this PR does / why we need it:

Allow to clean up volume-head when reverting to the parent of the volume-head.
Make the behavior of v1 and v2 volume consistent.

#### Special notes for your reviewer:

#### Additional documentation or context
