### PR TITLE
Updates for dm deferred deletion option and the ctrl-loss-tmo of "nvme connect"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.4.0
 	github.com/longhorn/backupstore v0.0.0-20240110081942-bd231cfb0c7b
 	github.com/longhorn/go-common-libs v0.0.0-20240103081802-3993c5908447
-	github.com/longhorn/go-spdk-helper v0.0.0-20240111043333-3afa7627b1aa
+	github.com/longhorn/go-spdk-helper v0.0.0-20240117135122-26f8acb2a13d
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	go.uber.org/multierr v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/longhorn/backupstore v0.0.0-20240110081942-bd231cfb0c7b h1:euBbfDb6bn
 github.com/longhorn/backupstore v0.0.0-20240110081942-bd231cfb0c7b/go.mod h1:4cbJWtlrD2cGTQxQLtdlPTYopiJiusXH7CpOBrn/s3k=
 github.com/longhorn/go-common-libs v0.0.0-20240103081802-3993c5908447 h1:NwR+xCGLpAORmB1UwNfDkQj3vPNIVikJe/hZe9+BQe0=
 github.com/longhorn/go-common-libs v0.0.0-20240103081802-3993c5908447/go.mod h1:nIECQARppamt2zwFSdzADRTVKo/7izFwWIS3VWi7D/s=
-github.com/longhorn/go-spdk-helper v0.0.0-20240111043333-3afa7627b1aa h1:5AflxT58kroRA+DtmeJwSHLliash47JdrRXVTneGp1o=
-github.com/longhorn/go-spdk-helper v0.0.0-20240111043333-3afa7627b1aa/go.mod h1:9nZ5HbwviggK6l792X4l9fTivEWmiK3sXFaroiRp2yw=
+github.com/longhorn/go-spdk-helper v0.0.0-20240117135122-26f8acb2a13d h1:Yqt7DL478ir9LwHmuRRXWzKKyzKbvPkGadCeRQ3pv1o=
+github.com/longhorn/go-spdk-helper v0.0.0-20240117135122-26f8acb2a13d/go.mod h1:9nZ5HbwviggK6l792X4l9fTivEWmiK3sXFaroiRp2yw=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=

--- a/pkg/spdk/backup.go
+++ b/pkg/spdk/backup.go
@@ -225,7 +225,7 @@ func (b *Backup) CloseSnapshot(snapshotName, volumeName string) error {
 	}
 
 	b.log.Info("Stopping NVMe initiator")
-	if _, err := b.initiator.Stop(false, true); err != nil {
+	if _, err := b.initiator.Stop(false, false, true); err != nil {
 		return errors.Wrapf(err, "failed to stop NVMe initiator")
 	}
 

--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -292,7 +292,7 @@ func (e *Engine) Delete(spdkClient *spdkclient.Client, superiorPortAllocator *ut
 		if err != nil {
 			return err
 		}
-		if _, err := initiator.Stop(true, true); err != nil {
+		if _, err := initiator.Stop(true, true, true); err != nil {
 			return err
 		}
 

--- a/pkg/spdk/restore.go
+++ b/pkg/spdk/restore.go
@@ -162,7 +162,7 @@ func (r *Restore) CloseVolumeDev(volDev *os.File) error {
 	}
 
 	r.log.Info("Stopping NVMe initiator")
-	if _, err := r.initiator.Stop(false, false); err != nil {
+	if _, err := r.initiator.Stop(false, false, false); err != nil {
 		return errors.Wrapf(err, "failed to stop NVMe initiator")
 	}
 

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -60,7 +60,8 @@ func NewServer(ctx context.Context, portStart, portEnd int32) (*Server, error) {
 		helpertypes.DefaultCtrlrLossTimeoutSec,
 		helpertypes.DefaultReconnectDelaySec,
 		helpertypes.DefaultFastIOFailTimeoutSec,
-		helpertypes.DefaultTransportAckTimeout); err != nil {
+		helpertypes.DefaultTransportAckTimeout,
+		helpertypes.DefaultKeepAliveTimeoutMs); err != nil {
 		return nil, errors.Wrap(err, "failed to set nvme options")
 	}
 

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/nvme/nvmecli.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/nvme/nvmecli.go
@@ -15,6 +15,9 @@ const (
 	nvmeBinary = "nvme"
 
 	DefaultTransportType = "tcp"
+
+	// Set short ctrlLossTimeoutSec for quick response to the controller loss.
+	defaultCtrlLossTimeoutSec = 30
 )
 
 type Device struct {
@@ -303,6 +306,7 @@ func connect(hostID, hostNQN, nqn, transpotType, ip, port string, executor *comm
 		"connect",
 		"-t", transpotType,
 		"--nqn", nqn,
+		"--ctrl-loss-tmo", strconv.Itoa(defaultCtrlLossTimeoutSec),
 		"-o", "json",
 	}
 

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/client/basic.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/client/basic.go
@@ -615,12 +615,15 @@ func (c *Client) BdevNvmeGetControllers(name string) (controllerInfoList []spdkt
 // "fastIOFailTimeoutSec": Fast I/O failure timeout in seconds
 //
 // "transportAckTimeout": Time to wait ack until retransmission for RDMA or connection close for TCP. Range 0-31 where 0 means use default
-func (c *Client) BdevNvmeSetOptions(ctrlrLossTimeoutSec, reconnectDelaySec, fastIOFailTimeoutSec, transportAckTimeout int32) (result bool, err error) {
+//
+// "keepAliveTimeoutMs": Keep alive timeout in milliseconds.
+func (c *Client) BdevNvmeSetOptions(ctrlrLossTimeoutSec, reconnectDelaySec, fastIOFailTimeoutSec, transportAckTimeout, keepAliveTimeoutMs int32) (result bool, err error) {
 	req := spdktypes.BdevNvmeSetOptionsRequest{
 		CtrlrLossTimeoutSec:  ctrlrLossTimeoutSec,
 		ReconnectDelaySec:    reconnectDelaySec,
 		FastIOFailTimeoutSec: fastIOFailTimeoutSec,
 		TransportAckTimeout:  transportAckTimeout,
+		KeepAliveTimeoutMs:   keepAliveTimeoutMs,
 	}
 
 	cmdOutput, err := c.jsonCli.SendCommand("bdev_nvme_set_options", req)
@@ -843,7 +846,7 @@ func (c *Client) NvmfSubsystemsGetNss(nqn, bdevName string, nsid uint32) (nsList
 //
 //		"trtype": Required. NVMe-oF target trtype: "tcp", "rdma" or "pcie". "tcp" by default.
 //
-//	 	"adrfam": Required. Address family ("IPv4", "IPv6", "IB", or "FC"). "IPv4" by default.
+//	 	"adrfam": Required. Address family ("ipv4", "ipv6", "ib", or "fc"). "ipv4" by default.
 func (c *Client) NvmfSubsystemAddListener(nqn, traddr, trsvcid string, trtype spdktypes.NvmeTransportType, adrfam spdktypes.NvmeAddressFamily) (created bool, err error) {
 	req := spdktypes.NvmfSubsystemAddListenerRequest{
 		Nqn: nqn,

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/types/nvme.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/types/nvme.go
@@ -114,6 +114,7 @@ type BdevNvmeSetOptionsRequest struct {
 	ReconnectDelaySec    int32 `json:"reconnect_delay_sec"`
 	FastIOFailTimeoutSec int32 `json:"fast_io_fail_timeout_sec"`
 	TransportAckTimeout  int32 `json:"transport_ack_timeout"`
+	KeepAliveTimeoutMs   int32 `json:"keep_alive_timeout_ms"`
 }
 
 type BdevNvmeGetControllersRequest struct {

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/types/types.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/types/types.go
@@ -29,6 +29,8 @@ const (
 	// detection, transport_ack_timeout should be set.
 	DefaultTransportAckTimeout = 14
 
+	DefaultKeepAliveTimeoutMs = 10000
+
 	ExecuteTimeout = 60 * time.Second
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -64,7 +64,7 @@ github.com/longhorn/go-common-libs/sync
 github.com/longhorn/go-common-libs/sys
 github.com/longhorn/go-common-libs/types
 github.com/longhorn/go-common-libs/utils
-# github.com/longhorn/go-spdk-helper v0.0.0-20240111043333-3afa7627b1aa
+# github.com/longhorn/go-spdk-helper v0.0.0-20240117135122-26f8acb2a13d
 ## explicit; go 1.21
 github.com/longhorn/go-spdk-helper/pkg/jsonrpc
 github.com/longhorn/go-spdk-helper/pkg/nvme


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/7697

#### What this PR does / why we need it:

- Allow derferred dm device deletion accordingly
    When deleting a replica, no need to delete a dm device by a blocking method.

- Pass DefaultKeepAliveTimeoutMs to BdevNvmeSetOptions

#### Special notes for your reviewer:

#### Additional documentation or context

Deps on https://github.com/longhorn/go-spdk-helper/pull/70
