### PR TITLE
spdk: Blindly finish rebuilding for src replica after rebuilding failure

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -938,6 +938,10 @@ func (e *Engine) ReplicaShallowCopy(dstReplicaName, dstReplicaAddress string) (e
 	defer func() {
 		// Blindly mark the rebuilding replica as mode ERR now.
 		if err != nil {
+			// Blindly send rebuilding finish for src replica.
+			if srcReplicaErr := srcReplicaServiceCli.ReplicaRebuildingSrcFinish(srcReplicaName, dstReplicaName); srcReplicaErr != nil {
+				e.log.WithError(srcReplicaErr).Errorf("Failed to finish rebuilding for src replica %s with address %s after rebuilding failure, will do nothing", srcReplicaName, srcReplicaAddress)
+			}
 			e.Lock()
 			if e.ReplicaModeMap[dstReplicaName] != types.ModeERR {
 				e.ReplicaModeMap[dstReplicaName] = types.ModeERR

--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -1130,7 +1130,7 @@ func (r *Replica) RebuildingSrcFinish(spdkClient *spdkclient.Client, dstReplicaN
 		}
 	case spdktypes.BdevTypeNvme:
 		if err = r.RebuildingSrcDetach(spdkClient, dstReplicaName); err != nil {
-			r.log.WithError(err).Errorf("Failed to unexpose rebuilding dst dev %s for dst replica %s, will do nothing but just clean up rebuilding dst info", r.rebuildingDstBdevName, r.rebuildingDstReplicaName)
+			r.log.WithError(err).Errorf("Failed to detach rebuilding dst dev %s for dst replica %s, will do nothing but just clean up rebuilding dst info", r.rebuildingDstBdevName, r.rebuildingDstReplicaName)
 		}
 	default:
 		r.log.Errorf("Found unknown rebuilding dst bdev type %s with name %s for replica %s rebuilding src finish, will do nothing but just clean up rebuilding dst info", r.rebuildingDstBdevType, r.rebuildingDstBdevName, r.Name)
@@ -1154,7 +1154,7 @@ func (r *Replica) RebuildingSrcAttach(spdkClient *spdkclient.Client, dstReplicaN
 	if r.rebuildingDstBdevName != "" {
 		controllerName := helperutil.GetNvmeControllerNameFromNamespaceName(r.rebuildingDstBdevName)
 		if dstRebuildingLvolName != controllerName {
-			return fmt.Errorf("found mismatching between the required dst bdev nvme controller name %s and the expected dst controller name %s for replica %s rebuilding src unexpose", dstRebuildingLvolName, controllerName, r.Name)
+			return fmt.Errorf("found mismatching between the required dst bdev nvme controller name %s and the expected dst controller name %s for replica %s rebuilding src attach", dstRebuildingLvolName, controllerName, r.Name)
 		}
 		return nil
 	}
@@ -1193,7 +1193,7 @@ func (r *Replica) RebuildingSrcDetach(spdkClient *spdkclient.Client, dstReplicaN
 	dstRebuildingLvolName := dstReplicaName
 	controllerName := helperutil.GetNvmeControllerNameFromNamespaceName(r.rebuildingDstBdevName)
 	if dstRebuildingLvolName != controllerName {
-		return fmt.Errorf("found mismatching between the required dst bdev nvme controller name %s and the expected dst controller name %s for replica %s rebuilding src unexpose", dstRebuildingLvolName, controllerName, r.Name)
+		return fmt.Errorf("found mismatching between the required dst bdev nvme controller name %s and the expected dst controller name %s for replica %s rebuilding src detach", dstRebuildingLvolName, controllerName, r.Name)
 	}
 
 	if _, err := spdkClient.BdevNvmeDetachController(controllerName); err != nil && !jsonrpc.IsJSONRPCRespErrorNoSuchDevice(err) {


### PR DESCRIPTION
After rebuilding failed, the previous rebuilding info in the source replica won't be cleaned up. Then the following rebuilding cannot use that source replica anymore.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/7723

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
