### PR TITLE
Protect spdkClient in ReplicaCreate

### DIFF
--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -344,7 +344,9 @@ func (s *Server) ReplicaCreate(ctx context.Context, req *spdkrpc.ReplicaCreateRe
 		return nil, err
 	}
 
+	s.RLock()
 	spdkClient := s.spdkClient
+	s.RUnlock()
 
 	return r.Create(spdkClient, req.ExposeRequired, req.PortCount, s.portAllocator)
 }


### PR DESCRIPTION
Protect spdkClient in ReplicaCreate when replacing the client when there is a connection issue.


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#7752

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
