### PR TITLE
 Expose local logical volumes and attach them to the local node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/longhorn/backupstore v0.0.0-20240509144945-3bce6e69af15
 	github.com/longhorn/go-common-libs v0.0.0-20240511041328-e68a6cd889d4
-	github.com/longhorn/go-spdk-helper v0.0.0-20240511070845-856928309b2c
+	github.com/longhorn/go-spdk-helper v0.0.0-20240513081816-b39d930c60ca
 	github.com/longhorn/types v0.0.0-20240510221052-ab949bbedea3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/longhorn/backupstore v0.0.0-20240509144945-3bce6e69af15 h1:D838/RWPKm
 github.com/longhorn/backupstore v0.0.0-20240509144945-3bce6e69af15/go.mod h1:n210xpMUVrSn/W4Za/9BZhyXLCTVfAOq5lNdLrRSyz8=
 github.com/longhorn/go-common-libs v0.0.0-20240511041328-e68a6cd889d4 h1:q10ATUXOqZtuPQqiqaudxTVnQZwYKMI6Jw77xsjvt/g=
 github.com/longhorn/go-common-libs v0.0.0-20240511041328-e68a6cd889d4/go.mod h1:gFXUEciTv/03ncyA8CNrfVkbikvSWNqCYwwsTC3lFGg=
-github.com/longhorn/go-spdk-helper v0.0.0-20240511070845-856928309b2c h1:sdKo5O0WM06vJmRKe22V9siBGH1K1SBrA9GfbkrHA4s=
-github.com/longhorn/go-spdk-helper v0.0.0-20240511070845-856928309b2c/go.mod h1:qyzk0ElwaCCVpVbjgcjuXNDnEG/Vd4GfSaeuVnxsFEE=
+github.com/longhorn/go-spdk-helper v0.0.0-20240513081816-b39d930c60ca h1:nyYFfP+33UzycHm83qRpML+srDHZT+7okZgctCq82Hk=
+github.com/longhorn/go-spdk-helper v0.0.0-20240513081816-b39d930c60ca/go.mod h1:qyzk0ElwaCCVpVbjgcjuXNDnEG/Vd4GfSaeuVnxsFEE=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
 github.com/longhorn/types v0.0.0-20240510221052-ab949bbedea3 h1:yCn2uYikI3xW3i1HHpKytitJ2lc7S5obDMKIa7ZIuc8=

--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -18,6 +18,7 @@ import (
 	btypes "github.com/longhorn/backupstore/types"
 	butil "github.com/longhorn/backupstore/util"
 	commonNet "github.com/longhorn/go-common-libs/net"
+	commonUtils "github.com/longhorn/go-common-libs/utils"
 	"github.com/longhorn/go-spdk-helper/pkg/jsonrpc"
 	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
 	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
@@ -662,7 +663,8 @@ func (r *Replica) Create(spdkClient *spdkclient.Client, exposeRequired bool, por
 	r.portAllocator = util.NewBitmap(r.PortStart+1, r.PortEnd)
 
 	if exposeRequired {
-		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.Name), headSvcLvol.UUID, podIP, strconv.Itoa(int(r.PortStart))); err != nil {
+		nguid := commonUtils.RandomID(nvmeNguidLength)
+		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.Name), headSvcLvol.UUID, nguid, podIP, strconv.Itoa(int(r.PortStart))); err != nil {
 			return nil, err
 		}
 		r.IsExposeRequired = true
@@ -1055,7 +1057,8 @@ func (r *Replica) SnapshotRevert(spdkClient *spdkclient.Client, snapshotName str
 		if err := spdkClient.StopExposeBdev(helpertypes.GetNQN(r.Name)); err != nil && !jsonrpc.IsJSONRPCRespErrorNoSuchDevice(err) {
 			return nil, err
 		}
-		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.Name), headLvolUUID, r.IP, strconv.Itoa(int(r.PortStart))); err != nil {
+		nguid := commonUtils.RandomID(nvmeNguidLength)
+		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.Name), headLvolUUID, nguid, r.IP, strconv.Itoa(int(r.PortStart))); err != nil {
 			return nil, err
 		}
 	}
@@ -1304,7 +1307,8 @@ func (r *Replica) RebuildingDstStart(spdkClient *spdkclient.Client, exposeRequir
 	r.rebuildingLvol = r.ActiveChain[r.ChainLength-1]
 	if exposeRequired {
 		if !r.IsExposed {
-			if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.rebuildingLvol.Name), r.rebuildingLvol.UUID, r.IP, strconv.Itoa(int(r.PortStart))); err != nil {
+			nguid := commonUtils.RandomID(nvmeNguidLength)
+			if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.rebuildingLvol.Name), r.rebuildingLvol.UUID, nguid, r.IP, strconv.Itoa(int(r.PortStart))); err != nil {
 				return "", err
 			}
 			r.IsExposeRequired = true
@@ -1541,7 +1545,8 @@ func (r *Replica) RebuildingDstSnapshotRevert(spdkClient *spdkclient.Client, sna
 	}
 
 	if r.IsExposed {
-		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.rebuildingLvol.Name), r.rebuildingLvol.UUID, r.IP, strconv.Itoa(int(r.PortStart))); err != nil {
+		nguid := commonUtils.RandomID(nvmeNguidLength)
+		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.rebuildingLvol.Name), r.rebuildingLvol.UUID, nguid, r.IP, strconv.Itoa(int(r.PortStart))); err != nil {
 			return err
 		}
 	}

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -706,10 +706,9 @@ func (s *Server) EngineCreate(ctx context.Context, req *spdkrpc.EngineCreateRequ
 	s.engineMap[req.Name] = NewEngine(req.Name, req.VolumeName, req.Frontend, req.SpecSize, s.updateChs[types.InstanceTypeEngine])
 	e := s.engineMap[req.Name]
 	spdkClient := s.spdkClient
-	replicaLvsNameMap := s.getLocalReplicaLvsNameMap(req.ReplicaAddressMap)
 	s.Unlock()
 
-	return e.Create(spdkClient, req.ReplicaAddressMap, replicaLvsNameMap, req.PortCount, s.portAllocator)
+	return e.Create(spdkClient, req.ReplicaAddressMap, req.PortCount, s.portAllocator)
 }
 
 func (s *Server) getLocalReplicaLvsNameMap(replicaMap map[string]string) (replicaLvsNameMap map[string]string) {

--- a/pkg/spdk/types.go
+++ b/pkg/spdk/types.go
@@ -23,6 +23,8 @@ const (
 	RebuildingSnapshotNamePrefix = "rebuild"
 
 	SyncTimeout = 60 * time.Minute
+
+	nvmeNguidLength = 32
 )
 
 func GetReplicaSnapshotLvolNamePrefix(replicaName string) string {

--- a/pkg/spdk/util.go
+++ b/pkg/spdk/util.go
@@ -10,6 +10,7 @@ import (
 	"github.com/longhorn/go-spdk-helper/pkg/nvme"
 
 	commonNs "github.com/longhorn/go-common-libs/ns"
+	commonUtils "github.com/longhorn/go-common-libs/utils"
 	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
 	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
 	helpertypes "github.com/longhorn/go-spdk-helper/pkg/types"
@@ -25,8 +26,8 @@ func exposeSnapshotLvolBdev(spdkClient *spdkclient.Client, lvsName, lvolName, ip
 	}
 
 	portStr := strconv.Itoa(int(port))
-
-	err = spdkClient.StartExposeBdev(helpertypes.GetNQN(lvolName), bdevLvolList[0].UUID, ip, portStr)
+	nguid := commonUtils.RandomID(nvmeNguidLength)
+	err = spdkClient.StartExposeBdev(helpertypes.GetNQN(lvolName), bdevLvolList[0].UUID, nguid, ip, portStr)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "failed to expose snapshot lvol bdev %v", lvolName)
 	}

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/client/advanced.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/client/advanced.go
@@ -1,8 +1,9 @@
 package client
 
 import (
-	"github.com/longhorn/go-spdk-helper/pkg/jsonrpc"
 	"path/filepath"
+
+	"github.com/longhorn/go-spdk-helper/pkg/jsonrpc"
 
 	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
 )
@@ -50,7 +51,7 @@ func (c *Client) DeleteDevice(bdevAioName, lvsName string) (err error) {
 	return nil
 }
 
-func (c *Client) StartExposeBdev(nqn, bdevName, ip, port string) error {
+func (c *Client) StartExposeBdev(nqn, bdevName, nguid, ip, port string) error {
 	nvmfTransportList, err := c.NvmfGetTransports("", "")
 	if err != nil {
 		return err
@@ -65,7 +66,7 @@ func (c *Client) StartExposeBdev(nqn, bdevName, ip, port string) error {
 		return err
 	}
 
-	if _, err := c.NvmfSubsystemAddNs(nqn, bdevName); err != nil {
+	if _, err := c.NvmfSubsystemAddNs(nqn, bdevName, nguid); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/client/basic.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/client/basic.go
@@ -798,10 +798,15 @@ func (c *Client) NvmfGetSubsystems(nqn, tgtName string) (subsystemList []spdktyp
 //	"nqn": Required. Subsystem NQN.
 //
 //	"bdevName": Required. Name of bdev to expose as a namespace.
-func (c *Client) NvmfSubsystemAddNs(nqn, bdevName string) (nsid uint32, err error) {
+//
+//	"nguid": Optional. Namespace globally unique identifier.
+func (c *Client) NvmfSubsystemAddNs(nqn, bdevName, nguid string) (nsid uint32, err error) {
 	req := spdktypes.NvmfSubsystemAddNsRequest{
-		Nqn:       nqn,
-		Namespace: spdktypes.NvmfSubsystemNamespace{BdevName: bdevName},
+		Nqn: nqn,
+		Namespace: spdktypes.NvmfSubsystemNamespace{
+			BdevName: bdevName,
+			Nguid:    nguid,
+		},
 	}
 
 	cmdOutput, err := c.jsonCli.SendCommand("nvmf_subsystem_add_ns", req)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/longhorn/go-common-libs/sync
 github.com/longhorn/go-common-libs/sys
 github.com/longhorn/go-common-libs/types
 github.com/longhorn/go-common-libs/utils
-# github.com/longhorn/go-spdk-helper v0.0.0-20240511070845-856928309b2c
+# github.com/longhorn/go-spdk-helper v0.0.0-20240513081816-b39d930c60ca
 ## explicit; go 1.22.0
 github.com/longhorn/go-spdk-helper/pkg/jsonrpc
 github.com/longhorn/go-spdk-helper/pkg/nvme


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#8551

#### What this PR does / why we need it:

Expose local logical volumes and attach them to the local node
    
1. Expose local logical volumes and attach them to the local node
2. To expose a logical volume and attach it to the local node, NGUID should be provided.
    
    

#### Special notes for your reviewer:

#### Additional documentation or context
