### PR TITLE
Replace getBdevNameForReplica with connectReplica

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -140,7 +140,7 @@ func (e *Engine) Create(spdkClient *spdkclient.Client, replicaAddressMap map[str
 
 	replicaBdevList := []string{}
 	for replicaName, replicaAddr := range replicaAddressMap {
-		bdevName, err := e.getBdevNameForReplica(spdkClient, replicaName, replicaAddr, podIP)
+		bdevName, err := e.connectReplica(spdkClient, replicaName, replicaAddr)
 		if err != nil {
 			e.log.WithError(err).Errorf("Failed to get bdev from replica %s with address %s, will skip it and continue", replicaName, replicaAddr)
 			e.ReplicaModeMap[replicaName] = types.ModeERR
@@ -172,10 +172,6 @@ func (e *Engine) Create(spdkClient *spdkclient.Client, replicaAddressMap map[str
 	e.log.Info("Created engine")
 
 	return e.getWithoutLock(), nil
-}
-
-func (e *Engine) getBdevNameForReplica(spdkClient *spdkclient.Client, replicaName, replicaAddress, podIP string) (bdevName string, err error) {
-	return e.connectReplica(spdkClient, replicaName, replicaAddress)
 }
 
 func (e *Engine) connectReplica(spdkClient *spdkclient.Client, replicaName, replicaAddress string) (bdevName string, err error) {
@@ -825,7 +821,7 @@ func (e *Engine) ReplicaAddFinish(spdkClient *spdkclient.Client, replicaName, re
 			replicaBdevList = append(replicaBdevList, e.ReplicaBdevNameMap[rName])
 		}
 		if rName == replicaName {
-			bdevName, err := e.getBdevNameForReplica(spdkClient, replicaName, replicaAddress, e.IP)
+			bdevName, err := e.connectReplica(spdkClient, replicaName, replicaAddress)
 			if err != nil {
 				e.log.WithError(err).Errorf("Failed to get bdev from rebuilding replica %s with address %s, will mark it as ERR and error out", replicaName, replicaAddress)
 				e.ReplicaModeMap[replicaName] = types.ModeERR


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#6001

#### What this PR does / why we need it:

Function name getBdevNameForReplica is misleading.

#### Special notes for your reviewer:

#### Additional documentation or context
