### PR TITLE
engine: add timestamp to user created snapshot

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -9,6 +9,7 @@ import (
 
 type SnapshotOptions struct {
 	UserCreated bool
+	Timestamp   string
 }
 
 type Replica struct {
@@ -28,14 +29,15 @@ type Replica struct {
 }
 
 type Lvol struct {
-	Name         string          `json:"name"`
-	UUID         string          `json:"uuid"`
-	SpecSize     uint64          `json:"spec_size"`
-	ActualSize   uint64          `json:"actual_size"`
-	Parent       string          `json:"parent"`
-	Children     map[string]bool `json:"children"`
-	CreationTime string          `json:"creation_time"`
-	UserCreated  bool            `json:"user_created"`
+	Name              string          `json:"name"`
+	UUID              string          `json:"uuid"`
+	SpecSize          uint64          `json:"spec_size"`
+	ActualSize        uint64          `json:"actual_size"`
+	Parent            string          `json:"parent"`
+	Children          map[string]bool `json:"children"`
+	CreationTime      string          `json:"creation_time"`
+	UserCreated       bool            `json:"user_created"`
+	SnapshotTimestamp string          `json:"snapshot_timestamp"`
 }
 
 func ProtoLvolToLvol(l *spdkrpc.Lvol) *Lvol {
@@ -45,12 +47,13 @@ func ProtoLvolToLvol(l *spdkrpc.Lvol) *Lvol {
 	return &Lvol{
 		Name: l.Name,
 		// UUID:         l.Uuid,
-		SpecSize:     l.SpecSize,
-		ActualSize:   l.ActualSize,
-		Parent:       l.Parent,
-		Children:     l.Children,
-		CreationTime: l.CreationTime,
-		UserCreated:  l.UserCreated,
+		SpecSize:          l.SpecSize,
+		ActualSize:        l.ActualSize,
+		Parent:            l.Parent,
+		Children:          l.Children,
+		CreationTime:      l.CreationTime,
+		UserCreated:       l.UserCreated,
+		SnapshotTimestamp: l.SnapshotTimestamp,
 	}
 }
 
@@ -61,12 +64,13 @@ func LvolToProtoLvol(l *Lvol) *spdkrpc.Lvol {
 	return &spdkrpc.Lvol{
 		Name: l.Name,
 		// Uuid:         l.UUID,
-		SpecSize:     l.SpecSize,
-		ActualSize:   l.ActualSize,
-		Parent:       l.Parent,
-		Children:     l.Children,
-		CreationTime: l.CreationTime,
-		UserCreated:  l.UserCreated,
+		SpecSize:          l.SpecSize,
+		ActualSize:        l.ActualSize,
+		Parent:            l.Parent,
+		Children:          l.Children,
+		CreationTime:      l.CreationTime,
+		UserCreated:       l.UserCreated,
+		SnapshotTimestamp: l.SnapshotTimestamp,
 	}
 }
 

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -452,7 +452,12 @@ func (s *Server) ReplicaSnapshotCreate(ctx context.Context, req *spdkrpc.Snapsho
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find replica %s during snapshot create", req.Name)
 	}
 
-	return r.SnapshotCreate(spdkClient, req.SnapshotName, &api.SnapshotOptions{UserCreated: req.UserCreated})
+	opts := &api.SnapshotOptions{
+		UserCreated: req.UserCreated,
+		Timestamp:   req.SnaphotTimestamp,
+	}
+
+	return r.SnapshotCreate(spdkClient, req.SnapshotName, opts)
 }
 
 func (s *Server) ReplicaSnapshotDelete(ctx context.Context, req *spdkrpc.SnapshotRequest) (ret *emptypb.Empty, err error) {
@@ -660,7 +665,12 @@ func (s *Server) ReplicaRebuildingDstSnapshotCreate(ctx context.Context, req *sp
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find replica %s during rebuilding dst snapshot create", req.Name)
 	}
 
-	if err = r.RebuildingDstSnapshotCreate(spdkClient, req.SnapshotName, &api.SnapshotOptions{UserCreated: req.UserCreated}); err != nil {
+	opts := &api.SnapshotOptions{
+		UserCreated: req.UserCreated,
+		Timestamp:   req.SnaphotTimestamp,
+	}
+
+	if err = r.RebuildingDstSnapshotCreate(spdkClient, req.SnapshotName, opts); err != nil {
 		return nil, err
 	}
 	return &emptypb.Empty{}, nil

--- a/pkg/spdk_test.go
+++ b/pkg/spdk_test.go
@@ -230,7 +230,7 @@ func (s *TestSuite) TestSPDKMultipleThread(c *C) {
 			c.Assert(cksumBefore1, Not(Equals), "")
 
 			snapshotName1 := "snap1"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName1, &api.SnapshotOptions{UserCreated: true})
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName1)
 			c.Assert(err, IsNil)
 
 			_, err = ne.Execute(nil, "dd", []string{"if=/dev/urandom", fmt.Sprintf("of=%s", endpoint), "bs=1M", fmt.Sprintf("count=%d", dataCountInMB), "seek=200", "status=none"}, defaultTestExecuteTimeout)
@@ -240,7 +240,7 @@ func (s *TestSuite) TestSPDKMultipleThread(c *C) {
 			c.Assert(cksumBefore2, Not(Equals), "")
 
 			snapshotName2 := "snap2"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName2, &api.SnapshotOptions{UserCreated: true})
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName2)
 			c.Assert(err, IsNil)
 
 			// Check both replica snapshot map after the snapshot operations
@@ -494,7 +494,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore11, Not(Equals), "")
 			snapshotName11 := "snap11"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName11, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName11)
 			c.Assert(err, IsNil)
 
 			offsetInMB = dataCountInMB
@@ -504,7 +504,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore12, Not(Equals), "")
 			snapshotName12 := "snap12"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName12, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName12)
 			c.Assert(err, IsNil)
 
 			offsetInMB = 2 * dataCountInMB
@@ -514,7 +514,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore13, Not(Equals), "")
 			snapshotName13 := "snap13"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName13, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName13)
 			c.Assert(err, IsNil)
 
 			offsetInMB = 3 * dataCountInMB
@@ -524,7 +524,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore14, Not(Equals), "")
 			snapshotName14 := "snap14"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName14, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName14)
 			c.Assert(err, IsNil)
 
 			offsetInMB = 4 * dataCountInMB
@@ -534,7 +534,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore15, Not(Equals), "")
 			snapshotName15 := "snap15"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName15, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName15)
 			c.Assert(err, IsNil)
 
 			// Current snapshot tree (with backing image):
@@ -586,7 +586,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore21, Not(Equals), "")
 			snapshotName21 := "snap21"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName21, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName21)
 			c.Assert(err, IsNil)
 
 			offsetInMB = 4 * dataCountInMB
@@ -596,7 +596,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore22, Not(Equals), "")
 			snapshotName22 := "snap22"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName22, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName22)
 			c.Assert(err, IsNil)
 
 			offsetInMB = 5 * dataCountInMB
@@ -606,7 +606,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore23, Not(Equals), "")
 			snapshotName23 := "snap23"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName23, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName23)
 			c.Assert(err, IsNil)
 
 			// Current snapshot tree (with backing image):
@@ -696,7 +696,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore31, Not(Equals), "")
 			snapshotName31 := "snap31"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName31, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName31)
 			c.Assert(err, IsNil)
 
 			offsetInMB = 2 * dataCountInMB
@@ -706,7 +706,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore32, Not(Equals), "")
 			snapshotName32 := "snap32"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName32, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName32)
 			c.Assert(err, IsNil)
 
 			err = spdkCli.EngineSnapshotDelete(engineName, snapshotName31)
@@ -754,7 +754,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore41, Not(Equals), "")
 			snapshotName41 := "snap41"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName41, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName41)
 			c.Assert(err, IsNil)
 			offsetInMB = 2 * dataCountInMB
 			_, err = ne.Execute(nil, "dd", []string{"if=/dev/urandom", fmt.Sprintf("of=%s", endpoint), "bs=1M", fmt.Sprintf("count=%d", dataCountInMB), fmt.Sprintf("seek=%d", offsetInMB), "status=none"}, defaultTestExecuteTimeout)
@@ -763,7 +763,7 @@ func (s *TestSuite) TestSPDKMultipleThreadSnapshot(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(cksumBefore42, Not(Equals), "")
 			snapshotName42 := "snap42"
-			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName42, nil)
+			_, err = spdkCli.EngineSnapshotCreate(engineName, snapshotName42)
 			c.Assert(err, IsNil)
 
 			// Current snapshot tree (with backing image):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #7641

#### What this PR does / why we need it:

#### Special notes for your reviewer:

I added the timestamp only to the snapshots created by the user, because they are the only ones listed in the UI.

#### Additional documentation or context
