### PR TITLE
fix(engine): correct format for snapshot timestamp

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -1075,7 +1075,7 @@ func (e *Engine) SnapshotCreate(spdkClient *spdkclient.Client, inputSnapshotName
 
 	opts := &api.SnapshotOptions{
 		UserCreated: true,
-		Timestamp:   time.Now().String(),
+		Timestamp:   util.Now(),
 	}
 
 	return e.snapshotOperation(spdkClient, inputSnapshotName, SnapshotOperationCreate, opts)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #8862

#### What this PR does / why we need it:

The snapshot creation time is now in the right `RFC3339` format

#### Special notes for your reviewer:

#### Additional documentation or context
