### PR TITLE
fix(snapshot): revert "engine: sync only own device before snapshot"

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -1261,7 +1261,8 @@ func (e *Engine) snapshotOperation(spdkClient *spdkclient.Client, inputSnapshotN
 				e.log.WithError(err).Errorf("WARNING: failed to get the executor for snapshot op %v with snapshot %s, will skip the sync and continue", snapshotOp, inputSnapshotName)
 			} else {
 				e.log.Infof("Requesting system sync %v before snapshot", devicePath)
-				if _, err := ne.Execute(nil, "sync", []string{devicePath}, SyncTimeout); err != nil {
+				// TODO: only sync the device path rather than all filesystems
+				if _, err := ne.Execute(nil, "sync", []string{}, SyncTimeout); err != nil {
 					// sync should never fail though, so it more like due to the nsenter
 					e.log.WithError(err).Errorf("WARNING: failed to sync for snapshot op %v with snapshot %s, will skip the sync and continue", snapshotOp, inputSnapshotName)
 				}


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#8977

#### What this PR does / why we need it:

The commit (da2a02e) results in a regression that v2 volume data are not sync before taking a snapshot. Using sync directly with a block device path does not work as expected.

According to the doc of the sync command, what it does is to synchronize the filesystem which contains the specified file.

#### Special notes for your reviewer:

#### Additional documentation or context
