### PR TITLE
fix(deps): update go-spdk-helper for user_created fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/longhorn/backupstore v0.0.0-20240720163059-56c90cd23634
 	github.com/longhorn/go-common-libs v0.0.0-20240720044518-32fc527fe868
-	github.com/longhorn/go-spdk-helper v0.0.0-20240720064915-d2ce0846d2a7
+	github.com/longhorn/go-spdk-helper v0.0.0-20240722084521-fe00dc625215
 	github.com/longhorn/types v0.0.0-20240706151541-33cb010c3544
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/longhorn/backupstore v0.0.0-20240720163059-56c90cd23634 h1:gfrFl0YwZS
 github.com/longhorn/backupstore v0.0.0-20240720163059-56c90cd23634/go.mod h1:7L/qcMq6IK3S/VU52AtmeKCnOK9Tz1XmMilzo2ILEm8=
 github.com/longhorn/go-common-libs v0.0.0-20240720044518-32fc527fe868 h1:B1L6EGHroqnGUC5shcoNJsLPRpfBa8c01/TPO68G0GI=
 github.com/longhorn/go-common-libs v0.0.0-20240720044518-32fc527fe868/go.mod h1:o01gaAiKE5NCd8+5i6csJSU4ELlW0Yn8GQ9U7pbXG9w=
-github.com/longhorn/go-spdk-helper v0.0.0-20240720064915-d2ce0846d2a7 h1:bwieBy2bUVi6sxFi2UbpXt292RykALG31yuChEYo66w=
-github.com/longhorn/go-spdk-helper v0.0.0-20240720064915-d2ce0846d2a7/go.mod h1:BxsYHvCYn/1rfohn5021Wt8tFYQb+unq1jItx8+htHY=
+github.com/longhorn/go-spdk-helper v0.0.0-20240722084521-fe00dc625215 h1:Gv53OXc4VQE8FVu50RdmhYBDqYATJmxvhNCbPVHV+F4=
+github.com/longhorn/go-spdk-helper v0.0.0-20240722084521-fe00dc625215/go.mod h1:BxsYHvCYn/1rfohn5021Wt8tFYQb+unq1jItx8+htHY=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
 github.com/longhorn/types v0.0.0-20240706151541-33cb010c3544 h1:U08l+0SbxCsododsraBHB5PdXrQme3TEh9iaREhRLQs=

--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -162,7 +162,7 @@ func BdevLvolInfoToServiceLvol(bdev *spdktypes.BdevInfo) *Lvol {
 		// Need to update this separately
 		Children:          map[string]*Lvol{},
 		CreationTime:      bdev.CreationTime,
-		UserCreated:       bdev.DriverSpecific.Lvol.Xattrs[spdkclient.UserCreated] == "true",
+		UserCreated:       bdev.DriverSpecific.Lvol.Xattrs[spdkclient.UserCreated] == strconv.FormatBool(true),
 		SnapshotTimestamp: bdev.DriverSpecific.Lvol.Xattrs[spdkclient.SnapshotTimestamp],
 	}
 }

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/client/basic.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/client/basic.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -273,6 +274,8 @@ func (c *Client) BdevLvolGet(name string, timeout uint64) (bdevLvolInfoList []sp
 		user_created, err := c.BdevLvolGetXattr(b.Name, UserCreated)
 		if err == nil {
 			b.DriverSpecific.Lvol.Xattrs[UserCreated] = user_created
+		} else {
+			b.DriverSpecific.Lvol.Xattrs[UserCreated] = strconv.FormatBool(true)
 		}
 		snapshot_timestamp, err := c.BdevLvolGetXattr(b.Name, SnapshotTimestamp)
 		if err == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -57,7 +57,7 @@ github.com/longhorn/go-common-libs/sync
 github.com/longhorn/go-common-libs/sys
 github.com/longhorn/go-common-libs/types
 github.com/longhorn/go-common-libs/utils
-# github.com/longhorn/go-spdk-helper v0.0.0-20240720064915-d2ce0846d2a7
+# github.com/longhorn/go-spdk-helper v0.0.0-20240722084521-fe00dc625215
 ## explicit; go 1.22.0
 github.com/longhorn/go-spdk-helper/pkg/jsonrpc
 github.com/longhorn/go-spdk-helper/pkg/nvme


### PR DESCRIPTION
Set user_created to true when the xattr isn´t available to let the UI to show the snapshots list.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #9054

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
