### PR TITLE
fix(disk): unable to unbind disk if it is failed to create it

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -929,8 +929,8 @@ func (c *SPDKClient) DiskGet(diskName, diskPath, diskDriver string) (*spdkrpc.Di
 }
 
 func (c *SPDKClient) DiskDelete(diskName, diskUUID, diskPath, diskDriver string) error {
-	if diskName == "" || diskUUID == "" {
-		return fmt.Errorf("failed to delete disk: missing required parameters")
+	if diskName == "" {
+		return fmt.Errorf("failed to delete disk: missing required parameter disk name")
 	}
 
 	client := c.getSPDKServiceClient()

--- a/pkg/spdk/disk/virtio-scsi/virtio-scsi.go
+++ b/pkg/spdk/disk/virtio-scsi/virtio-scsi.go
@@ -2,6 +2,7 @@ package virtioscsi
 
 import (
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	commonTypes "github.com/longhorn/go-common-libs/types"
 	"github.com/longhorn/go-spdk-helper/pkg/jsonrpc"
@@ -32,6 +33,16 @@ func (d *DiskDriverVirtioScsi) DiskCreate(spdkClient *spdkclient.Client, diskNam
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to bind virtio-scsi disk %v", diskPath)
 	}
+	defer func() {
+		if err != nil {
+			logrus.WithError(err).Warnf("Unbinding virtio-scsi disk %v since failed to attach", diskPath)
+
+			_, errUnbind := spdksetup.Unbind(diskPath, executor)
+			if errUnbind != nil {
+				logrus.WithError(errUnbind).Warnf("Failed to unbind virtio-scsi disk %v since failed to attach", diskPath)
+			}
+		}
+	}()
 
 	bdevs, err := spdkClient.BdevVirtioAttachController(diskName, "pci", diskPath, "scsi")
 	if err != nil {


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#9126

#### What this PR does / why we need it:

- If disk UUID is not provided while deleting a disk. Use disk name instead.
- Unbind a disk if failed to attach it while attaching.


#### Special notes for your reviewer:

#### Additional documentation or context
