### PR TITLE
fix: spdk replica lists its own lvols so that everyone won't be affected by others

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/longhorn/backupstore v0.0.0-20241013024428-b52180a5191f
 	github.com/longhorn/go-common-libs v0.0.0-20241012153249-4c71f1cbdd9e
-	github.com/longhorn/go-spdk-helper v0.0.0-20240922062342-22115a91cbe9
+	github.com/longhorn/go-spdk-helper v0.0.0-20241017032159-f0613870a0b5
 	github.com/longhorn/types v0.0.0-20241007141758-3640f2357238
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/longhorn/backupstore v0.0.0-20241013024428-b52180a5191f h1:p2DmYXbpCS
 github.com/longhorn/backupstore v0.0.0-20241013024428-b52180a5191f/go.mod h1:Wv5tV0/Jv2OuYo8ZcpgsLVOS4xos2qKLrLQ7pgWsfFY=
 github.com/longhorn/go-common-libs v0.0.0-20241012153249-4c71f1cbdd9e h1:ux8DZoSohmkA4vpvmlw8ow5pGsaSiVRAONkGx7l1R1Y=
 github.com/longhorn/go-common-libs v0.0.0-20241012153249-4c71f1cbdd9e/go.mod h1:ypnoivZeYoZVRqeI2MQHEGA+Vqt8DZVkCbhf/3Ogx7Q=
-github.com/longhorn/go-spdk-helper v0.0.0-20240922062342-22115a91cbe9 h1:DVYw6dzssMcCOAQSqXLVJIQQiKdZD7lAKfnU2ZTf4Mo=
-github.com/longhorn/go-spdk-helper v0.0.0-20240922062342-22115a91cbe9/go.mod h1:pKbJjuJN69T+qDaJIkR1NcpGqCzj/vGv1NTTDiaE5s0=
+github.com/longhorn/go-spdk-helper v0.0.0-20241017032159-f0613870a0b5 h1:GTvdzXoXm9KmcnAucY5kRVOYBhRqR/1t50A/Ja6//GM=
+github.com/longhorn/go-spdk-helper v0.0.0-20241017032159-f0613870a0b5/go.mod h1:bcuZXckBY6XdJ/IY3VFbDfsSGhoPLVeg5QZ2Av5JcAo=
 github.com/longhorn/types v0.0.0-20241007141758-3640f2357238 h1:zo3jTRYbH1KtO2TwgIt3eb4wTLGAfN/SAzWJsOwY+Pc=
 github.com/longhorn/types v0.0.0-20241007141758-3640f2357238/go.mod h1:IpV+1bctQgBgp3brj0nsHmnBDFkd5IrzTgBtVAloJuw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/pkg/spdk/types.go
+++ b/pkg/spdk/types.go
@@ -172,7 +172,11 @@ func GetBdevMap(cli *spdkclient.Client) (map[string]*spdktypes.BdevInfo, error) 
 }
 
 func GetBdevLvolMap(cli *spdkclient.Client) (map[string]*spdktypes.BdevInfo, error) {
-	bdevList, err := cli.BdevLvolGet("", 0)
+	return GetBdevLvolMapWithFilter(cli, func(*spdktypes.BdevInfo) bool { return true })
+}
+
+func GetBdevLvolMapWithFilter(cli *spdkclient.Client, filter func(*spdktypes.BdevInfo) bool) (map[string]*spdktypes.BdevInfo, error) {
+	bdevList, err := cli.BdevLvolGetWithFilter("", 0, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -64,7 +64,7 @@ github.com/longhorn/go-common-libs/sync
 github.com/longhorn/go-common-libs/sys
 github.com/longhorn/go-common-libs/types
 github.com/longhorn/go-common-libs/utils
-# github.com/longhorn/go-spdk-helper v0.0.0-20240922062342-22115a91cbe9
+# github.com/longhorn/go-spdk-helper v0.0.0-20241017032159-f0613870a0b5
 ## explicit; go 1.22.0
 github.com/longhorn/go-spdk-helper/pkg/jsonrpc
 github.com/longhorn/go-spdk-helper/pkg/nvme


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
longhorn/longhorn#9121

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced filtering for logical volume operations, enhancing precision during synchronization and deletion.
	- Added a new method for retrieving logical volumes with customizable filters.

- **Bug Fixes**
	- Improved error handling and logging related to the new filtering mechanism.

- **Chores**
	- Updated Go version and dependencies to ensure compatibility and access to new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->