### PR TITLE
fix: always return 0 index if lvol is not provided when finding index

### DIFF
--- a/pkg/spdk/backup.go
+++ b/pkg/spdk/backup.go
@@ -408,10 +408,9 @@ func (b *Backup) constructMappings() *btypes.Mappings {
 
 func (b *Backup) findIndex(lvolName string) int {
 	if lvolName == "" {
-		if b.replica.BackingImage != nil {
-			return 0
-		}
-		return 1
+		// Note that, 0 can be a backing image if ActiveChanin[0] is not nil.
+		// Caller should handle this case
+		return 0
 	}
 
 	for i, lvol := range b.replica.ActiveChain {


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/10013

Always return 0 if lvolName is not provided
Note that, 0 can be a BackingImage is ActiveChain[0] != nil
Caller need to handle this case.