### PR TITLE
fix: reconstruct ActiveChain and SnapshotLvolMap while creating replica

### DIFF
--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -3,7 +3,6 @@ package spdk
 import (
 	"fmt"
 	"net"
-	"reflect"
 	"strconv"
 	"sync"
 	"time"
@@ -332,7 +331,7 @@ func (s *Server) verify() (err error) {
 			}
 		}
 	}
-	if !reflect.DeepEqual(s.replicaMap, replicaMap) {
+	if len(s.replicaMap) != len(replicaMap) {
 		logrus.Infof("spdk gRPC server: Replica map updated, map count is changed from %d to %d", len(s.replicaMap), len(replicaMap))
 	}
 	s.replicaMap = replicaMap


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10033

#### What this PR does / why we need it:

If the replica's ActiveChain is not constructed while creating the replica, the mismatch found by the `validateAndUpdate()` will result in the error state.
    
    ```
    ....
            newSnapshotLvolMap, err := constructSnapshotLvolMap(r.Name, bdevLvolMap)
            if err != nil {
                    return err
            }
            if len(r.SnapshotLvolMap) != len(newSnapshotLvolMap) {
                    return fmt.Errorf("replica current active snapshot ....")
            }
    ...
    ````

#### Special notes for your reviewer:

#### Additional documentation or context
