### PR TITLE
fix(server): fix race conditions

### DIFF
--- a/pkg/util/http_handler.go
+++ b/pkg/util/http_handler.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	DownloadBufferSize = 1 << 12
-	HTTPTimeout        = 4 * time.Second
+	HTTPTimeout        = 10 * time.Second
 )
 
 type ProgressUpdater interface {

--- a/scripts/test
+++ b/scripts/test
@@ -58,4 +58,4 @@ trap "rm -f /tmp/test-disk" EXIT
 start_spdk_tgt
 trap stop_spdk_tgt EXIT
 
-go test -v -race -cover ${PACKAGES} -coverprofile=coverage.out -timeout 30m
+go test -v -p 1 -race -cover ${PACKAGES} -coverprofile=coverage.out -timeout 30m


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#9953

#### What this PR does / why we need it:

- fix(server): add replica to replicaMap after replica creation and initialization
- fix race conditions in spdk_tgt.go
- fix(scripts): prevent different test suites from running concurrently
- fix(backingimage): increase HTTPTimeout to 10 seconds

#### Special notes for your reviewer:

#### Additional documentation or context
