### PR TITLE
fix: reconstruct the cache for failed replica restarting

### DIFF
--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -803,8 +803,8 @@ func (r *Replica) Create(spdkClient *spdkclient.Client, portCount int32, superio
 		return nil, err
 	}
 
-	// In case of failed replica reuse being failed by r.validateAndUpdate(), we should make sure the caches are correct.
-	if r.reconstructRequired {
+	// In case of failed replica reuse/restart being errored by r.validateAndUpdate(), we should make sure the caches are correct.
+	if r.State == types.InstanceStatePending && r.reconstructRequired {
 		bdevLvolMap, err := GetBdevLvolMapWithFilter(spdkClient, r.replicaLvolFilter)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9488

#### What this PR does / why we need it:

If the upper layer tries to launch a previously failed replica in a newly launched instance manager pod. The pod may have no info then directly treat it as a new replica and skip the cache reconstruction. Finally, this replica will be failed by r.validateAndUpdate() in the next moment.


#### Special notes for your reviewer:

#### Additional documentation or context
