### PR TITLE
fix: delete lvol with empty base snapshot

### DIFF
--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -958,9 +958,6 @@ func (r *Replica) Delete(spdkClient *spdkclient.Client, cleanupRequired bool, su
 				}
 				continue
 			}
-			if bdevLvol.DriverSpecific.Lvol.BaseSnapshot == "" {
-				continue
-			}
 			r.CleanupLvolTree(spdkClient, lvolName, bdevLvolMap)
 		}
 	}


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10116

#### What this PR does / why we need it:

Reproduce steps:
1. Create a v2 volume
2. Take one snapshot
3. Delete the v2 volume
4. Go the instance-manager pod and check the orphaned lvols by `go-spdk-lvol lvol get`


#### Special notes for your reviewer:

#### Additional documentation or context
