### PR TITLE
fix: replica address is missing in the backup status response

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -1912,7 +1912,10 @@ func (e *Engine) BackupCreate(backupName, volumeName, engineName, snapshotName, 
 	e.log.Infof("Creating backup %s", backupName)
 
 	e.Lock()
-	defer e.Unlock()
+	defer func() {
+		e.Unlock()
+		e.UpdateCh <- nil
+	}()
 
 	replicaName, replicaAddress := "", ""
 	for name, replicaStatus := range e.ReplicaStatusMap {

--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -209,6 +209,12 @@ func NewReplica(ctx context.Context, replicaName, lvsName, lvsUUID string, specS
 	}
 }
 
+func (r *Replica) GetAddress() string {
+	r.RLock()
+	defer r.RUnlock()
+	return net.JoinHostPort(r.IP, strconv.Itoa(int(r.PortStart)))
+}
+
 func (r *Replica) IsRebuilding() bool {
 	r.RLock()
 	defer r.RUnlock()

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -1365,12 +1365,18 @@ func (s *Server) ReplicaBackupStatus(ctx context.Context, req *spdkrpc.BackupSta
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find backup %v", req.Backup)
 	}
 
+	replicaAddress := ""
+	if backup.replica != nil {
+		replicaAddress = fmt.Sprintf("tcp://%s", backup.replica.GetAddress())
+	}
+
 	return &spdkrpc.BackupStatusResponse{
-		Progress:     int32(backup.Progress),
-		BackupUrl:    backup.BackupURL,
-		Error:        backup.Error,
-		SnapshotName: backup.SnapshotName,
-		State:        string(backup.State),
+		Progress:       int32(backup.Progress),
+		BackupUrl:      backup.BackupURL,
+		Error:          backup.Error,
+		SnapshotName:   backup.SnapshotName,
+		State:          string(backup.State),
+		ReplicaAddress: replicaAddress,
 	}, nil
 }
 


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10136

#### What this PR does / why we need it:

Replica address is missing in the backup status response. The replica address is required for test_basic.py::test_backup_status_for_unavailable_replicas.

#### Special notes for your reviewer:

#### Additional documentation or context
