### PR TITLE
fix: bdev names of replicas are empty while creating a raid bdev

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -2146,12 +2146,19 @@ func (e *Engine) BackupRestoreFinish(spdkClient *spdkclient.Client) error {
 			return err
 		}
 		e.log.Infof("Attaching replica %s with address %s before finishing restoration", replicaName, replicaAddress)
-		_, err = spdkClient.BdevNvmeAttachController(replicaName, helpertypes.GetNQN(replicaName), replicaIP, replicaPort,
+		nvmeBdevNameList, err := spdkClient.BdevNvmeAttachController(replicaName, helpertypes.GetNQN(replicaName), replicaIP, replicaPort,
 			spdktypes.NvmeTransportTypeTCP, spdktypes.NvmeAddressFamilyIPv4,
 			int32(e.ctrlrLossTimeout), replicaReconnectDelaySec, int32(e.fastIOFailTimeoutSec), replicaMultipath)
 		if err != nil {
 			return err
 		}
+
+		if len(nvmeBdevNameList) != 1 {
+			return fmt.Errorf("got unexpected nvme bdev list %v", nvmeBdevNameList)
+		}
+
+		replicaStatus.BdevName = nvmeBdevNameList[0]
+
 		replicaBdevList = append(replicaBdevList, replicaStatus.BdevName)
 	}
 


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10139

#### What this PR does / why we need it:

Bdev names of replicas are empty while creating a raid bdev after finishing backup restore.

#### Special notes for your reviewer:

#### Additional documentation or context
