### PR TITLE
fix: skip write zero when dumping backing image data to lvol

### DIFF
--- a/pkg/spdk/backing_image.go
+++ b/pkg/spdk/backing_image.go
@@ -730,7 +730,7 @@ func (bi *BackingImage) prepareFromSync(targetFh *os.File, fromAddress, srcLvsUU
 
 	ctx, cancel := context.WithCancel(bi.ctx)
 	defer cancel()
-	_, err = util.IdleTimeoutCopy(ctx, cancel, srcFh, targetFh, bi, true)
+	_, err = util.IdleTimeoutCopy(ctx, cancel, srcFh, targetFh, bi, false)
 	if err != nil {
 		return errors.Wrapf(err, "failed to copy the source backing image %v in lvsUUID %v with address %v", bi.Name, srcLvsUUID, exposedSnapshotLvolAddress)
 	}

--- a/pkg/util/http_handler.go
+++ b/pkg/util/http_handler.go
@@ -82,7 +82,7 @@ func (h *HTTPHandler) DownloadFromURL(ctx context.Context, url string, outFh *os
 		return 0, fmt.Errorf("expected status code 200 from %s, got %s", url, resp.Status)
 	}
 
-	copied, err := IdleTimeoutCopy(ctx, cancel, resp.Body, outFh, updater, true)
+	copied, err := IdleTimeoutCopy(ctx, cancel, resp.Body, outFh, updater, false)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/9876

Since @derekbit has fixed the issue of spdk lvol init doesn't clean up the old data 
We can now skip writing the data when dumping backing image data to lvol 