### PR TITLE
fix: fix backing image size calculation

### DIFF
--- a/pkg/spdk/backing_image.go
+++ b/pkg/spdk/backing_image.go
@@ -131,7 +131,7 @@ func (bi *BackingImage) Create(spdkClient *spdkclient.Client, superiorPortAlloca
 		if err != nil {
 			bi.log.WithError(err).Error("Failed to create backing image")
 		}
-		// update the backing image afte preparing
+		// update the backing image after preparing
 		bi.UpdateCh <- nil
 	}()
 

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -286,7 +286,7 @@ func (s *Server) verify() (err error) {
 				logrus.WithError(err).Warnf("failed to extract backing image name and disk UUID from lvol name %v", lvolName)
 				continue
 			}
-			actualSize := bdevLvol.DriverSpecific.Lvol.NumAllocatedClusters * uint64(defaultClusterSize)
+			size := bdevLvol.NumBlocks * uint64(bdevLvol.BlockSize)
 			alias := bdevLvol.Aliases[0]
 			expectedChecksum, err := GetSnapXattr(spdkClient, alias, types.BackingImageSnapshotAttrChecksum)
 			if err != nil {
@@ -298,7 +298,7 @@ func (s *Server) verify() (err error) {
 				logrus.WithError(err).Warnf("failed to retrieve backing image UUID attribute for snapshot %v", alias)
 				continue
 			}
-			backingImage := NewBackingImage(s.ctx, backingImageName, backingImageUUID, lvsUUID, actualSize, expectedChecksum, s.updateChs[types.InstanceTypeBackingImage])
+			backingImage := NewBackingImage(s.ctx, backingImageName, backingImageUUID, lvsUUID, size, expectedChecksum, s.updateChs[types.InstanceTypeBackingImage])
 			backingImage.Alias = alias
 			// For uncahced backing image, we set the state to pending first, so we can distinguish it from the cached but starting backing image
 			backingImage.State = types.BackingImageStatePending


### PR DESCRIPTION
ref: [longhorn/longhorn 10342](https://github.com/longhorn/longhorn/issues/10342)

Since we skip writing zero into the lvol when creating v2 backing image
the size of the backing image should be `bdevLvol.NumBlocks * uint64(bdevLvol.BlockSize)` instead of using `NumAllocatedClusters`

For example, parrot is 32 MB but it only allocates 6 clusters
We should report 32MB when getting the backing image size.