### PR TITLE
fix: fix v2 snapshot attribute key name checksum conflict

### DIFF
--- a/pkg/spdk/backing_image.go
+++ b/pkg/spdk/backing_image.go
@@ -259,7 +259,7 @@ func (bi *BackingImage) ValidateAndUpdate(spdkClient *spdkclient.Client) (err er
 	}
 	snapSvcLvol := BdevLvolInfoToServiceLvol(&bdevLvolList[0])
 	bi.Snapshot = snapSvcLvol
-	state, err := GetSnapXattr(spdkClient, bi.Alias, types.BackingImageSnapshotAttrPrepareState)
+	state, err := GetSnapXattr(spdkClient, bi.Alias, types.LonghornBackingImageSnapshotAttrPrepareState)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get the prepare state for backing image snapshot %v", bi.Name)
 	}
@@ -612,17 +612,17 @@ func (bi *BackingImage) createSnapshotFromTempHead(spdkClient *spdkclient.Client
 
 	var xattrs []spdkclient.Xattr
 	checksum := spdkclient.Xattr{
-		Name:  types.BackingImageSnapshotAttrChecksum,
+		Name:  types.LonghornBackingImageSnapshotAttrChecksum,
 		Value: bi.ExpectedChecksum,
 	}
 	xattrs = append(xattrs, checksum)
 	backingImageUUID := spdkclient.Xattr{
-		Name:  types.BackingImageSnapshotAttrBackingImageUUID,
+		Name:  types.LonghornBackingImageSnapshotAttrUUID,
 		Value: bi.BackingImageUUID,
 	}
 	xattrs = append(xattrs, backingImageUUID)
 	prepareState := spdkclient.Xattr{
-		Name:  types.BackingImageSnapshotAttrPrepareState,
+		Name:  types.LonghornBackingImageSnapshotAttrPrepareState,
 		Value: string(bi.State),
 	}
 	xattrs = append(xattrs, prepareState)

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -291,12 +291,12 @@ func (s *Server) verify() (err error) {
 			}
 			size := bdevLvol.NumBlocks * uint64(bdevLvol.BlockSize)
 			alias := bdevLvol.Aliases[0]
-			expectedChecksum, err := GetSnapXattr(spdkClient, alias, types.BackingImageSnapshotAttrChecksum)
+			expectedChecksum, err := GetSnapXattr(spdkClient, alias, types.LonghornBackingImageSnapshotAttrChecksum)
 			if err != nil {
 				logrus.WithError(err).Warnf("failed to retrieve checksum attribute for backing image snapshot %v", alias)
 				continue
 			}
-			backingImageUUID, err := GetSnapXattr(spdkClient, alias, types.BackingImageSnapshotAttrBackingImageUUID)
+			backingImageUUID, err := GetSnapXattr(spdkClient, alias, types.LonghornBackingImageSnapshotAttrUUID)
 			if err != nil {
 				logrus.WithError(err).Warnf("failed to retrieve backing image UUID attribute for snapshot %v", alias)
 				continue

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -48,10 +48,6 @@ const (
 
 const (
 	BackingImagePortCount = 1
-
-	BackingImageSnapshotAttrChecksum         = "checksum"
-	BackingImageSnapshotAttrBackingImageUUID = "backing_image_uuid"
-	BackingImageSnapshotAttrPrepareState     = "backing_image_prepare_state"
 )
 
 const VolumeHead = "volume-head"
@@ -94,4 +90,11 @@ const (
 
 	// SPDKShallowCopyStateNew is the state returned from spdk_tgt. There is no underscore in the string.
 	SPDKShallowCopyStateInProgress = "in progress"
+)
+
+// Longhorn defined snapshot attributes
+const (
+	LonghornBackingImageSnapshotAttrChecksum     = "longhorn_backing_image_checksum"
+	LonghornBackingImageSnapshotAttrUUID         = "longhorn_backing_image_uuid"
+	LonghornBackingImageSnapshotAttrPrepareState = "longhorn_backing_image_prepare_state"
 )


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/10399

change the attr key name used by backing image
we should add a longhorn prefix to the preserved attr name in spdk