### PR TITLE
test: only one SPDK CI test is allowed at a time by using a file lock

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -e
 
+LOCK_FILE="/tmp/longhorn-spdk.lock"
+MAX_WAIT=36000  # seconds
+
+# Try to acquire exclusive lock on $LOCK_FILE using file descriptor 200
+# If the lock is held by another process, wait and retry
+# Try to acquire exclusive lock on $LOCK_FILE using file descriptor 200
+# Wait up to $MAX_WAIT seconds
+exec 200>"$LOCK_FILE"
+if ! flock -w "$MAX_WAIT" 200; then
+  echo "Failed to acquire lock on $LOCK_FILE after $MAX_WAIT seconds. Exiting."
+  exit 1
+fi
+
 cd "$(dirname $0)"/..
 
 echo Running unit tests


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10684

#### What this PR does / why we need it:

During CI testing, spdk_tgt is repeatedly started and stopped. To prevent interference between concurrent CI tasks, only one SPDK CI test is allowed at a time by using a file lock.


#### Special notes for your reviewer:

#### Additional documentation or context
