### PR TITLE
test: reduce the concurrentCount to 5

### DIFF
--- a/pkg/spdk_test.go
+++ b/pkg/spdk_test.go
@@ -240,7 +240,7 @@ func (s *TestSuite) TestSPDKMultipleThread(c *C) {
 		c.Assert(err, IsNil)
 	}()
 
-	concurrentCount := 10
+	concurrentCount := 5
 	dataCountInMB := 100
 	wg := sync.WaitGroup{}
 	wg.Add(concurrentCount)
@@ -586,7 +586,7 @@ func (s *TestSuite) spdkMultipleThreadSnapshotOpsAndRebuilding(c *C, withBacking
 		}
 	}
 
-	concurrentCount := 10
+	concurrentCount := 5
 	dataCountInMB := int64(10)
 	wg := sync.WaitGroup{}
 	wg.Add(concurrentCount)
@@ -1614,7 +1614,7 @@ func (s *TestSuite) spdkMultipleThreadFastRebuilding(c *C, withBackingImage bool
 		backingImageName = bi.Name
 	}
 
-	concurrentCount := 10
+	concurrentCount := 5
 	dataCountInMB := int64(100)
 	wg := sync.WaitGroup{}
 	wg.Add(concurrentCount)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

concurrentCount to 10 takes 3-4 hours to complete. To reduce the CI test time, change the concurrentCount to 5.

#### Special notes for your reviewer:

#### Additional documentation or context
