### PR TITLE
chore(Dockerfile): fix arm64 build failed

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -27,7 +27,7 @@ RUN zypper -n addrepo --refresh https://download.opensuse.org/repositories/syste
     zypper -n addrepo --refresh https://download.opensuse.org/repositories/devel:languages:python:Factory/15.6/devel:languages:python:Factory.repo && \
     zypper --gpg-auto-import-keys ref
 
-RUN zypper -n install liburing-devel
+RUN zypper -n install liburing2-devel
 RUN zypper -n install cmake curl wget gcc unzip tar xsltproc docbook-xsl-stylesheets python311 python311-pip fuse3-devel \
               e2fsprogs xfsprogs util-linux-systemd libcmocka-devel device-mapper procps jq
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

SPDK ublk needs liburing2.

- amd64 liburing-devel is already liburing2.
- arm64 needs to install liburing2-devel explicitly.

ref: https://github.com/spdk/spdk/issues/3282
#### Special notes for your reviewer:

#### Additional documentation or context
