### PR TITLE
fix: parent field of a backing image returned to the instance manager should be empty

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -47,12 +47,16 @@ func ProtoLvolToLvol(l *spdkrpc.Lvol) *Lvol {
 	if l == nil {
 		return nil
 	}
+	parent := l.Parent
+	if types.IsBackingImageSnapLvolName(parent) {
+		parent = ""
+	}
 	return &Lvol{
 		Name: l.Name,
 		// UUID:         l.Uuid,
 		SpecSize:          l.SpecSize,
 		ActualSize:        l.ActualSize,
-		Parent:            l.Parent,
+		Parent:            parent,
 		Children:          l.Children,
 		CreationTime:      l.CreationTime,
 		UserCreated:       l.UserCreated,

--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -1045,13 +1045,13 @@ func (e *Engine) checkAndUpdateInfoFromReplicaNoLock() {
 					currentReplicaAncestorName := ancestorApiLvol.Name
 					// The ancestor can be backing image, so we need to extract the backing image name from the lvol name
 					// Notice that, the disks are not the same for all the replicas, so their backing image lvol names are not the same.
-					if IsBackingImageSnapLvolName(candidateReplicaAncestorName) {
+					if types.IsBackingImageSnapLvolName(candidateReplicaAncestorName) {
 						candidateReplicaAncestorName, _, err = ExtractBackingImageAndDiskUUID(candidateReplicaAncestorName)
 						if err != nil {
 							e.log.WithError(err).Warnf("BUG: ancestor name %v is from backingImage.Snapshot lvol name, it should be a valid backing image lvol name", candidateReplicaAncestorName)
 						}
 					}
-					if IsBackingImageSnapLvolName(currentReplicaAncestorName) {
+					if types.IsBackingImageSnapLvolName(currentReplicaAncestorName) {
 						currentReplicaAncestorName, _, err = ExtractBackingImageAndDiskUUID(currentReplicaAncestorName)
 						if err != nil {
 							e.log.WithError(err).Warnf("BUG: ancestor name %v is from backingImage.Snapshot lvol name, it should be a valid backing image lvol name", currentReplicaAncestorName)
@@ -1626,7 +1626,7 @@ func getRebuildingSnapshotList(srcReplicaServiceCli *client.SPDKClient, srcRepli
 	ancestorSnapshotName, latestSnapshotName := "", ""
 	for snapshotName, snapApiLvol := range rpcSrcReplica.Snapshots {
 		// If parent is empty or the parent is a backing image snapshot, it's the ancestor snapshot
-		if snapApiLvol.Parent == "" || IsBackingImageSnapLvolName(snapApiLvol.Parent) {
+		if snapApiLvol.Parent == "" || types.IsBackingImageSnapLvolName(snapApiLvol.Parent) {
 			ancestorSnapshotName = snapshotName
 		}
 		if snapApiLvol.Children[types.VolumeHead] {

--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -242,7 +242,7 @@ func (r *Replica) replicaLvolFilter(bdev *spdktypes.BdevInfo) bool {
 	}
 	lvolName := spdktypes.GetLvolNameFromAlias(bdev.Aliases[0])
 	// it is okay to have backing image snapshot in the results, because we exclude it when finding root or construct the snapshot map
-	return IsReplicaLvol(r.Name, lvolName) || IsBackingImageSnapLvolName(lvolName)
+	return IsReplicaLvol(r.Name, lvolName) || types.IsBackingImageSnapLvolName(lvolName)
 }
 
 func (r *Replica) stopSnapshotHash(spdkClient *spdkclient.Client, parentLvol *Lvol) error {
@@ -996,7 +996,7 @@ func (r *Replica) Delete(spdkClient *spdkclient.Client, cleanupRequired bool, su
 			return err
 		}
 		for lvolName, bdevLvol := range bdevLvolMap {
-			if IsBackingImageSnapLvolName(lvolName) {
+			if types.IsBackingImageSnapLvolName(lvolName) {
 				for _, childLvolName := range bdevLvol.DriverSpecific.Lvol.Clones {
 					if !IsReplicaLvol(r.Name, childLvolName) {
 						continue
@@ -1907,7 +1907,7 @@ func (r *Replica) RebuildingDstStart(spdkClient *spdkclient.Client, srcReplicaNa
 		return "", err
 	}
 	for lvolName, lvol := range bdevLvolMap {
-		if IsBackingImageSnapLvolName(lvolName) {
+		if types.IsBackingImageSnapLvolName(lvolName) {
 			continue
 		}
 		if lvolName == r.Name {
@@ -2108,7 +2108,7 @@ func (r *Replica) doCleanupForRebuildingDst(spdkClient *spdkclient.Client) error
 			chainLvolMap[inChainLvol.Name] = inChainLvol
 		}
 		for lvolName, lvol := range bdevLvolMap {
-			if IsBackingImageSnapLvolName(lvolName) {
+			if types.IsBackingImageSnapLvolName(lvolName) {
 				continue
 			}
 			if lvolName == r.Name || IsRebuildingLvol(lvolName) || IsReplicaExpiredLvol(r.Name, lvolName) {
@@ -2160,7 +2160,7 @@ func (r *Replica) rebuildingDstShallowCopyPrepare(spdkClient *spdkclient.Client,
 		return "", fmt.Errorf("cannot find snapshot %s in the rebuilding snapshot list for replica %s shallow copy prepare", snapshotName, r.Name)
 	}
 	if srcSnapSvcLvol.Parent != "" {
-		if IsBackingImageSnapLvolName(srcSnapSvcLvol.Parent) {
+		if types.IsBackingImageSnapLvolName(srcSnapSvcLvol.Parent) {
 			if r.BackingImage == nil {
 				return "", fmt.Errorf("found a src snapshot lvol %s has parent backing image %s but the dst backing image lvol is nil for dst replica %v rebuilding snapshot %s shallow copy prepare", srcSnapSvcLvol.Name, srcSnapSvcLvol.Parent, r.Name, snapshotName)
 			}

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -258,11 +258,11 @@ func (s *Server) verify() (err error) {
 	// Backing image lvol name will be "bi-${biName}-disk-${lvsUUID}"
 	// Backing image temp lvol name will be "bi-${biName}-disk-${lvsUUID}-temp-head"
 	for lvolName, bdevLvol := range bdevLvolMap {
-		if bdevLvol.DriverSpecific.Lvol.Snapshot && !IsBackingImageSnapLvolName(lvolName) {
+		if bdevLvol.DriverSpecific.Lvol.Snapshot && !types.IsBackingImageSnapLvolName(lvolName) {
 			continue
 		}
-		if IsBackingImageTempHead(lvolName) {
-			if s.backingImageMap[GetBackingImageSnapLvolNameFromTempHeadLvolName(lvolName)] == nil {
+		if types.IsBackingImageTempHead(lvolName) {
+			if s.backingImageMap[types.GetBackingImageSnapLvolNameFromTempHeadLvolName(lvolName)] == nil {
 				lvsUUID := bdevLvol.DriverSpecific.Lvol.LvolStoreUUID
 				logrus.Infof("Found one backing image temp head lvol %v while there is no backing image record in the server", lvolName)
 				if err := cleanupOrphanBackingImageTempHead(spdkClient, lvsUUIDNameMap[lvsUUID], lvolName); err != nil {
@@ -282,7 +282,7 @@ func (s *Server) verify() (err error) {
 				continue
 			}
 		}
-		if IsBackingImageSnapLvolName(lvolName) {
+		if types.IsBackingImageSnapLvolName(lvolName) {
 			lvsUUID := bdevLvol.DriverSpecific.Lvol.LvolStoreUUID
 			backingImageName, _, err := ExtractBackingImageAndDiskUUID(lvolName)
 			if err != nil {

--- a/pkg/spdk/types.go
+++ b/pkg/spdk/types.go
@@ -26,8 +26,6 @@ const (
 	ReplicaExpiredLvolSuffix     = "expired"
 	RebuildingSnapshotNamePrefix = "rebuild"
 
-	BackingImageTempHeadLvolSuffix = "temp-head"
-
 	SyncTimeout = 60 * time.Minute
 
 	nvmeNguidLength = 32
@@ -166,20 +164,8 @@ func GetBackingImageSnapLvolName(backingImageName string, lvsUUID string) string
 	return fmt.Sprintf("bi-%s-disk-%s", backingImageName, lvsUUID)
 }
 
-func IsBackingImageSnapLvolName(lvolName string) bool {
-	return strings.HasPrefix(lvolName, "bi-") && !strings.HasSuffix(lvolName, BackingImageTempHeadLvolSuffix)
-}
-
 func GetBackingImageTempHeadLvolName(backingImageName string, lvsUUID string) string {
 	return fmt.Sprintf("bi-%s-disk-%s-temp-head", backingImageName, lvsUUID)
-}
-
-func GetBackingImageSnapLvolNameFromTempHeadLvolName(lvolName string) string {
-	return strings.TrimSuffix(lvolName, fmt.Sprintf("-%s", BackingImageTempHeadLvolSuffix))
-}
-
-func IsBackingImageTempHead(lvolName string) bool {
-	return strings.HasSuffix(lvolName, BackingImageTempHeadLvolSuffix)
 }
 
 func GetReplicaSnapshotLvolNamePrefix(replicaName string) string {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,6 +1,11 @@
 package types
 
-import "github.com/longhorn/types/pkg/generated/spdkrpc"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/longhorn/types/pkg/generated/spdkrpc"
+)
 
 type Mode string
 
@@ -103,3 +108,20 @@ const (
 	LonghornBackingImageSnapshotAttrUUID         = "longhorn_backing_image_uuid"
 	LonghornBackingImageSnapshotAttrPrepareState = "longhorn_backing_image_prepare_state"
 )
+
+// Backing image related utility functions
+const (
+	BackingImageTempHeadLvolSuffix = "temp-head"
+)
+
+func IsBackingImageSnapLvolName(lvolName string) bool {
+	return strings.HasPrefix(lvolName, "bi-") && !strings.HasSuffix(lvolName, BackingImageTempHeadLvolSuffix)
+}
+
+func GetBackingImageSnapLvolNameFromTempHeadLvolName(lvolName string) string {
+	return strings.TrimSuffix(lvolName, fmt.Sprintf("-%s", BackingImageTempHeadLvolSuffix))
+}
+
+func IsBackingImageTempHead(lvolName string) bool {
+	return strings.HasSuffix(lvolName, BackingImageTempHeadLvolSuffix)
+}


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10526

#### What this PR does / why we need it:

The parent field of a backing image returned to the instance manager should be empty.

#### Special notes for your reviewer:

#### Additional documentation or context
