### PR TITLE
fix: rebuilding replica ancestor snapshot will miss backing image

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -1625,7 +1625,8 @@ func getRebuildingSnapshotList(srcReplicaServiceCli *client.SPDKClient, srcRepli
 	}
 	ancestorSnapshotName, latestSnapshotName := "", ""
 	for snapshotName, snapApiLvol := range rpcSrcReplica.Snapshots {
-		// If parent is empty or the parent is a backing image snapshot, it's the ancestor snapshot
+		// If the parent is empty, it's the ancestor snapshot
+		// Notice that the ancestor snapshot parent is still empty even if there is a backing image
 		if snapApiLvol.Parent == "" || types.IsBackingImageSnapLvolName(snapApiLvol.Parent) {
 			ancestorSnapshotName = snapshotName
 		}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

Longhorn/longhorn#10909

#### What this PR does / why we need it:

Since the rebuilding snapshot list provided by the src replica will not tell if the ancestor snapshot has the backing image as its parent.

#### Special notes for your reviewer:

#### Additional documentation or context
