### PR TITLE
fix: server should scan possible existing replicas when adding a new disk

### DIFF
--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -675,6 +675,9 @@ func (r *Replica) prepareHead(spdkClient *spdkclient.Client, backingImage *Backi
 			}
 			r.log.Info("Replica created a new head lvol")
 		}
+	} else {
+		// The head lvol is already available, so we need to update the head cache
+		r.log.Info("Replica head lvol is already available, will directly reuse it")
 	}
 
 	// Blindly clean up then update the caches for the head

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -307,12 +307,13 @@ func (s *Server) verify() (err error) {
 			backingImage.State = types.BackingImageStatePending
 			backingImageMapForSync[lvolName] = backingImage
 			backingImageMap[lvolName] = backingImage
-		} else {
+		} else if IsProbablyReplicaName(lvolName) {
 			lvsUUID := bdevLvol.DriverSpecific.Lvol.LvolStoreUUID
 			specSize := bdevLvol.NumBlocks * uint64(bdevLvol.BlockSize)
 			actualSize := bdevLvol.DriverSpecific.Lvol.NumAllocatedClusters * uint64(defaultClusterSize)
 			replicaMap[lvolName] = NewReplica(s.ctx, lvolName, lvsUUIDNameMap[lvsUUID], lvsUUID, specSize, actualSize, s.updateChs[types.InstanceTypeReplica])
 			replicaMapForSync[lvolName] = replicaMap[lvolName]
+			logrus.Infof("Detected one possible existing replica %s(%s) with disk %s(%s), spec size %d, actual size %d", bdevLvol.Aliases[0], bdevLvol.UUID, lvsUUIDNameMap[lvsUUID], lvsUUID, specSize, actualSize)
 		}
 	}
 	for replicaName, r := range replicaMap {

--- a/pkg/spdk/types.go
+++ b/pkg/spdk/types.go
@@ -3,6 +3,7 @@ package spdk
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -158,6 +159,11 @@ func BdevLvolInfoToServiceLvol(bdev *spdktypes.BdevInfo) *Lvol {
 	}
 
 	return svcLvol
+}
+
+func IsProbablyReplicaName(name string) bool {
+	matched, _ := regexp.MatchString("^.+-r-[a-zA-Z0-9]{8}$", name)
+	return matched
 }
 
 func GetBackingImageSnapLvolName(backingImageName string, lvsUUID string) string {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue
https://github.com/longhorn/longhorn/issues/10828
https://github.com/longhorn/longhorn/issues/11188

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
