### PR TITLE
fix: handle the naming variant of uio_pci_generic and vfio_pci

### DIFF
--- a/pkg/spdk/disk/types_test.go
+++ b/pkg/spdk/disk/types_test.go
@@ -1,0 +1,83 @@
+package disk
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func (s *TestSuite) TestIsVfioPci(c *C) {
+	// Add test case for isVfioPci function
+	testCases := []struct {
+		name     string
+		driver   string
+		expected bool
+	}{
+		{
+			name:     "VfioPci with hyphen",
+			driver:   "vfio-pci",
+			expected: true,
+		},
+		{
+			name:     "VfioPci with underscore",
+			driver:   "vfio_pci",
+			expected: true,
+		},
+		{
+			name:     "Non-VfioPci driver",
+			driver:   "virtio-pci",
+			expected: false,
+		},
+		{
+			name:     "Empty driver",
+			driver:   "",
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		c.Logf("Running test case: %s", tc.name)
+		result := isVfioPci(tc.driver)
+		c.Assert(result, Equals, tc.expected, Commentf("Expected %v for driver %s, got %v", tc.expected, tc.driver, result))
+	}
+}
+
+func (s *TestSuite) TestIsUioPciGeneric(c *C) {
+	// Add test case for isUioPciGeneric function
+	testCases := []struct {
+		name     string
+		driver   string
+		expected bool
+	}{
+		{
+			name:     "UioPciGeneric with hyphen",
+			driver:   "uio-pci-generic",
+			expected: true,
+		},
+		{
+			name:     "UioPciGeneric with underscore",
+			driver:   "uio_pci_generic",
+			expected: true,
+		},
+		{
+			name:     "Non-UioPciGeneric driver",
+			driver:   "virtio-pci",
+			expected: false,
+		},
+		{
+			name:     "Empty driver",
+			driver:   "",
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		c.Logf("Running test case: %s", tc.name)
+		result := isUioPciGeneric(tc.driver)
+		c.Assert(result, Equals, tc.expected, Commentf("Expected %v for driver %s, got %v", tc.expected, tc.driver, result))
+	}
+}


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#11127

#### What this PR does / why we need it:

uio_pci_generic and vfio_pci are uio-pci-generic and vfio-pci on some OS like talos.

#### Special notes for your reviewer:

#### Additional documentation or context
