### PR TITLE
feat: support interrupt mode for NVMe/TCP

### DIFF
--- a/pkg/spdk/types.go
+++ b/pkg/spdk/types.go
@@ -52,12 +52,13 @@ const (
 	//
 	// If an I/O operation to a replica (base bdev) is unresponsive within 10 seconds, an I/O error is returned,
 	// and the base bdev is deleted after 5 seconds.
-	replicaCtrlrLossTimeoutSec  = 15
-	replicaReconnectDelaySec    = 2
-	replicaFastIOFailTimeoutSec = 10
-	replicaTransportAckTimeout  = 10
-	replicaKeepAliveTimeoutMs   = 10000
-	replicaMultipath            = "disable"
+	replicaCtrlrLossTimeoutSec       = 15
+	replicaReconnectDelaySec         = 2
+	replicaFastIOFailTimeoutSec      = 10
+	replicaTransportAckTimeout       = 10
+	replicaKeepAliveTimeoutMs        = 10000
+	replicaKeepAliveTimeoutMsDisable = 0
+	replicaMultipath                 = "disable"
 )
 
 type Lvol struct {

--- a/pkg/spdk_test.go
+++ b/pkg/spdk_test.go
@@ -127,7 +127,7 @@ func LaunchTestSPDKTarget(c *C, execute func(envs []string, name string, args []
 
 func LaunchTestSPDKGRPCServer(ctx context.Context, c *C, ip string, execute func(envs []string, name string, args []string, timeout time.Duration) (string, error), wg *sync.WaitGroup) {
 	LaunchTestSPDKTarget(c, execute)
-	srv, err := server.NewServer(ctx, defaultTestStartPort, defaultTestEndPort)
+	srv, err := server.NewServer(ctx, defaultTestStartPort, defaultTestEndPort, false)
 	c.Assert(err, IsNil)
 
 	spdkGRPCListener, err := net.Listen("tcp", net.JoinHostPort(ip, strconv.Itoa(types.SPDKServicePort)))


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9834, ~longhorn/longhorn#9419~

#### What this PR does / why we need it:

Support interrupt mode for NVMe/TCP

#### Special notes for your reviewer:

#### Additional documentation or context
