### PR TITLE
fix(backup): fallback to full backup if comparing snapshot is not an ancestor

### DIFF
--- a/pkg/spdk/backup.go
+++ b/pkg/spdk/backup.go
@@ -365,7 +365,9 @@ func (b *Backup) findSnapshotRange(lvolName, compareLvolName string) (from, to i
 	}
 
 	if from <= to {
-		return 0, 0, fmt.Errorf("invalid snapshot lvol range %v (%v) and %v (%v)", lvolName, from, compareLvolName, to)
+		b.log.Warnf("Last backup snapshot %s is not an ancestor of current snapshot %s; performing full backup instead",
+			compareLvolName, lvolName)
+		to = 0
 	}
 
 	if from > len(b.replica.ActiveChain)-1 {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11461

#### What this PR does / why we need it:

Previously, attempting to back up an older snapshot after a new snapshot was backed up would fail with `invalid snapshot lvol range` because the comparing snapshot was not a valid ancestor.

With this change, the backup falls back to a full backup when the comparing snapshot is not an ancestor, ensuring that older snapshots can be backed up reliably.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
