### PR TITLE
revert: feat(engine): add I/O suspension during replica deletion

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -1678,19 +1678,6 @@ func (e *Engine) ReplicaDelete(spdkClient *spdkclient.Client, replicaName, repli
 		return fmt.Errorf("replica %s recorded address %s does not match the input address %s for engine %s replica delete", replicaName, replicaStatus.Address, replicaAddress, e.Name)
 	}
 
-	if e.Frontend == types.FrontendSPDKTCPBlockdev && e.Endpoint != "" {
-		if err = e.initiator.Suspend(false, false); err != nil {
-			err = errors.Wrapf(err, "failed to suspend NVMe initiator during engine %s replica %s delete", e.Name, replicaName)
-			return err
-		}
-		defer func() {
-			if frontendErr := e.initiator.Resume(); frontendErr != nil {
-				frontendErr = errors.Wrapf(frontendErr, "failed to resume NVMe initiator during engine %s replica %s delete", e.Name, replicaName)
-				err = frontendErr
-			}
-		}()
-	}
-
 	e.log.Infof("Removing base bdev %v from engine", replicaStatus.BdevName)
 	if _, err := spdkClient.BdevRaidRemoveBaseBdev(replicaStatus.BdevName); err != nil && !jsonrpc.IsJSONRPCRespErrorNoSuchDevice(err) {
 		return errors.Wrapf(err, "failed to remove base bdev %s for deleting replica %s", replicaStatus.BdevName, replicaName)


### PR DESCRIPTION
This reverts commit f640e455c81df7c2d7b008263beae9528ace1a2f. Longhorn 11109

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # https://github.com/longhorn/longhorn/issues/11109

#### What this PR does / why we need it:
This PR reverts commit `f640e455c81df7c2d7b008263beae9528ace1a2f`.(https://github.com/longhorn/longhorn-spdk-engine/pull/376), which suspended I/O during replica deletion.
Although that change did not cause functional failures, it can negatively affect client I/O while a replica is being deleted. SPDK already performs an internal quiesce(suspension of I/O) during base bdev removal, so keeping the additional suspend increases client-visible impact. 


#### Special notes for your reviewer:

#### Additional documentation or context
