### PR TITLE
fix(replica): clean up temporary exposures when restore is cancelled

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -3019,12 +3019,13 @@ func (e *Engine) BackupRestoreFinish(spdkClient *spdkclient.Client) error {
 		if err != nil {
 			return err
 		}
-		e.log.Infof("Attaching replica %s with address %s before finishing restoration", replicaName, replicaAddress)
+		e.log.Infof("Attaching replica %s at address %s before finishing restoration", replicaName, replicaAddress)
 		nvmeBdevNameList, err := spdkClient.BdevNvmeAttachController(replicaName, helpertypes.GetNQN(replicaName), replicaIP, replicaPort,
 			spdktypes.NvmeTransportTypeTCP, spdktypes.NvmeAddressFamilyIPv4,
 			int32(e.ctrlrLossTimeout), replicaReconnectDelaySec, int32(e.fastIOFailTimeoutSec), replicaMultipath)
 		if err != nil {
-			return err
+			e.log.WithError(err).Infof("Failed to attach replica %s at address %s, skipping before finishing restoration", replicaName, replicaAddress)
+			continue
 		}
 
 		if len(nvmeBdevNameList) != 1 {

--- a/pkg/spdk/restore.go
+++ b/pkg/spdk/restore.go
@@ -173,16 +173,6 @@ func (r *Restore) CloseVolumeDev(volDev *os.File) error {
 		return errors.Wrapf(err, "failed to stop NVMe initiator")
 	}
 
-	if !r.replica.IsExposed {
-		r.log.Info("Unexposing lvol bdev")
-		lvolName := r.replica.Name
-		err := r.spdkClient.StopExposeBdev(helpertypes.GetNQN(lvolName))
-		if err != nil {
-			return errors.Wrapf(err, "failed to unexpose lvol bdev %v", lvolName)
-		}
-		r.replica.IsExposed = false
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#12412

#### What this PR does / why we need it:

https://github.com/longhorn/longhorn/issues/12412#issuecomment-3722260785

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
