### PR TITLE
feat(backupRestore): move backup restore workflow from replica to engine level

### DIFF
--- a/pkg/client/client_engine.go
+++ b/pkg/client/client_engine.go
@@ -439,7 +439,6 @@ func (c *SPDKClient) EngineBackupRestore(req *BackupRestoreRequest) error {
 	recv, err := client.EngineBackupRestore(ctx, &spdkrpc.EngineBackupRestoreRequest{
 		BackupUrl:       req.BackupUrl,
 		EngineName:      req.EngineName,
-		SnapshotName:    req.SnapshotName,
 		Credential:      req.Credential,
 		ConcurrentLimit: req.ConcurrentLimit,
 	})

--- a/pkg/spdk/backup_restore_test.go
+++ b/pkg/spdk/backup_restore_test.go
@@ -2,6 +2,7 @@ package spdk
 
 import (
 	"fmt"
+	"strings"
 
 	lhtypes "github.com/longhorn/longhorn-spdk-engine/pkg/types"
 
@@ -88,4 +89,40 @@ func (s *TestSuite) TestCheckAndUpdateInfoFromReplicasNoLockAllERRSkipped(c *C) 
 	// Modes remain ERR (not downgraded further)
 	c.Assert(e.ReplicaStatusMap["replica-1"].Mode, Equals, lhtypes.Mode(lhtypes.ModeERR))
 	c.Assert(e.ReplicaStatusMap["replica-2"].Mode, Equals, lhtypes.Mode(lhtypes.ModeERR))
+}
+
+func (s *TestSuite) TestEngineFrontendTeardownRestoreInitiatorMarksStopped(c *C) {
+	fmt.Println("Testing EngineFrontend.teardownRestoreInitiator marks the temporary restore frontend stopped")
+
+	ef := NewEngineFrontend("ef-a", "engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 1024, 0, 0, make(chan interface{}, 1))
+	ef.State = lhtypes.InstanceStateRunning
+	ef.IsRestoring = true
+	ef.Endpoint = "/dev/longhorn/vol-a"
+	ef.NvmeTcpFrontend.TargetIP = "10.0.0.1"
+	ef.NvmeTcpFrontend.TargetPort = 2000
+	ef.NvmeTcpFrontend.Nqn = getStableVolumeNQN("vol-a")
+	ef.NvmeTcpFrontend.Nguid = getStableVolumeNGUID("vol-a")
+
+	ef.teardownRestoreInitiator(nil)
+
+	c.Assert(string(ef.State), Equals, string(lhtypes.InstanceStateStopped))
+	c.Assert(ef.Frontend, Equals, "")
+	c.Assert(ef.Endpoint, Equals, "")
+	c.Assert(ef.NvmeTcpFrontend.TargetIP, Equals, "")
+	c.Assert(ef.NvmeTcpFrontend.TargetPort, Equals, int32(0))
+	c.Assert(ef.NvmeTcpFrontend.Nqn, Equals, "")
+	c.Assert(ef.NvmeTcpFrontend.Nguid, Equals, "")
+}
+
+func (s *TestSuite) TestEngineReplicaAddRejectedDuringRestore(c *C) {
+	fmt.Println("Testing Engine.ReplicaAdd is rejected while restore is in progress")
+
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendEmpty, 10, make(chan interface{}, 1))
+	e.State = lhtypes.InstanceStateRunning
+	e.IsRestoring = true
+
+	err := e.ReplicaAdd(nil, "replica-new", "10.0.0.2:20000", false, nil)
+
+	c.Assert(err, NotNil)
+	c.Assert(strings.Contains(err.Error(), "restore is in progress"), Equals, true)
 }

--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -123,7 +123,6 @@ type Engine struct {
 	SpecSize   uint64
 	ActualSize uint64
 	Frontend   string
-	Endpoint   string
 
 	ctrlrLossTimeout     int
 	fastIOFailTimeoutSec int
@@ -717,7 +716,6 @@ func (e *Engine) getWithoutLock() (res *spdkrpc.Engine) {
 		ReplicaModeMap:        map[string]spdkrpc.ReplicaMode{},
 		Snapshots:             map[string]*spdkrpc.Lvol{},
 		Frontend:              e.Frontend,
-		Endpoint:              e.Endpoint,
 		State:                 string(e.State),
 		ErrorMsg:              e.ErrorMsg,
 		IsExpanding:           e.isExpanding,
@@ -2117,7 +2115,6 @@ func (e *Engine) BackupRestore(spdkClient *spdkclient.Client, backupUrl, endpoin
 	defer func() {
 		if err != nil {
 			e.IsRestoring = false
-			e.Endpoint = ""
 		}
 	}()
 
@@ -2289,9 +2286,6 @@ func (e *Engine) completeBackupRestore(spdkClient *spdkclient.Client, backupSnap
 	if e.restore != nil {
 		oldSnapshotName = e.restore.SnapshotName
 	}
-
-	// Clear the endpoint; the EngineFrontend will tear down the initiator after doneCh closes.
-	e.Endpoint = ""
 
 	// Stop the temporary NVMe-TCP target and release its port.
 	if e.Frontend == types.FrontendEmpty {

--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -1,6 +1,7 @@
 package spdk
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -21,6 +22,8 @@ import (
 	"github.com/longhorn/go-spdk-helper/pkg/jsonrpc"
 	"github.com/longhorn/types/pkg/generated/spdkrpc"
 
+	btypes "github.com/longhorn/backupstore/types"
+	butil "github.com/longhorn/backupstore/util"
 	commonbitmap "github.com/longhorn/go-common-libs/bitmap"
 	commonnet "github.com/longhorn/go-common-libs/net"
 	commonutils "github.com/longhorn/go-common-libs/utils"
@@ -110,6 +113,11 @@ func (m *MockReplicaAdder) ReplicaAddFinish(srcReplicaServiceCli, dstReplicaServ
 type Engine struct {
 	sync.RWMutex
 
+	ctx       context.Context
+	cancelCtx context.CancelFunc
+
+	restore *EngineRestore
+
 	Name       string
 	VolumeName string
 	SpecSize   uint64
@@ -179,7 +187,12 @@ func NewEngine(engineName, volumeName, frontend string, specSize uint64, engineU
 	}
 	log.WithField("specSize", roundedSpecSize)
 
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
 	e := &Engine{
+		ctx:       ctx,
+		cancelCtx: cancelCtx,
+
 		Name:       engineName,
 		VolumeName: volumeName,
 		Frontend:   frontend,
@@ -592,6 +605,11 @@ func (e *Engine) Delete(spdkClient *spdkclient.Client, superiorPortAllocator *co
 	}()
 
 	e.log.Info("Deleting engine")
+	if e.IsRestoring && e.restore != nil {
+		e.log.Info("Canceling volume restoration before engine deletion")
+		e.cancelCtx()
+		e.restore.Stop()
+	}
 
 	e.log.Infof("Stopping to expose RAID bdev for engine %s", e.Name)
 	switch e.Frontend {
@@ -782,6 +800,9 @@ func (e *Engine) ReplicaAdd(spdkClient *spdkclient.Client, dstReplicaName, dstRe
 	// Syncing with the SPDK TGT server only when the engine is running.
 	if e.State != types.InstanceStateRunning {
 		return fmt.Errorf("invalid state %v for engine %s replica %s add start", e.State, e.Name, dstReplicaName)
+	}
+	if e.IsRestoring {
+		return fmt.Errorf("cannot add replica %s while engine %s restore is in progress", dstReplicaName, e.Name)
 	}
 
 	if _, exists := e.ReplicaStatusMap[dstReplicaName]; exists {
@@ -2050,212 +2071,382 @@ func (e *Engine) BackupStatus(backupName, replicaAddress string) (*spdkrpc.Backu
 	return replicaServiceCli.ReplicaBackupStatus(backupName)
 }
 
-func (e *Engine) BackupRestore(spdkClient *spdkclient.Client, backupUrl, engineName, snapshotName string, credential map[string]string, concurrentLimit int32) (*spdkrpc.EngineBackupRestoreResponse, error) {
+// BackupRestore initiates a backup restore for the engine.
+// It returns a done channel that is closed when the restore goroutine completes
+// (whether successfully, with an error, or cancelled). Callers that set up a
+// temporary frontend connection should wait on this channel before tearing it down.
+func (e *Engine) BackupRestore(spdkClient *spdkclient.Client, backupUrl, endpoint string, credential map[string]string, concurrentLimit int32, superiorPortAllocator *commonbitmap.Bitmap) (resp *spdkrpc.EngineBackupRestoreResponse, doneCh <-chan struct{}, err error) {
 	e.log.Infof("Restoring backup %s", backupUrl)
+
+	resp = &spdkrpc.EngineBackupRestoreResponse{
+		Errors: map[string]string{},
+	}
+
+	e.Lock()
+	if err := e.precheckBackupRestore(backupUrl); err != nil {
+		e.Unlock()
+		return resp, nil, err
+	}
+	e.Unlock()
+
+	backupInfo, err := backupstore.InspectBackup(backupUrl)
+	if err != nil {
+		return resp, nil, err
+	}
 
 	e.Lock()
 	defer e.Unlock()
 
-	resp := &spdkrpc.EngineBackupRestoreResponse{
-		Errors: map[string]string{},
-	}
-
-	backupInfo, err := backupstore.InspectBackup(backupUrl)
-	if err != nil {
-		for _, replicaStatus := range e.ReplicaStatusMap {
-			resp.Errors[replicaStatus.Address] = err.Error()
-		}
-		return resp, nil
+	// need to recheck the backup restore precheck after inspecting the backup,
+	// because we release the lock during backup inspection which can take a long time, and the engine state may change when we reacquire the lock.
+	if err := e.precheckBackupRestore(backupUrl); err != nil {
+		return resp, nil, err
 	}
 
 	if backupInfo.VolumeSize != int64(e.SpecSize) {
-		return nil, fmt.Errorf("the backup volume %v size %v must be the same as the Longhorn volume size %v", backupInfo.VolumeName, backupInfo.VolumeSize, e.SpecSize)
+		return resp, nil, fmt.Errorf("the backup volume %v size %v must be the same as the Longhorn volume size %v", backupInfo.VolumeName, backupInfo.VolumeSize, e.SpecSize)
 	}
 
-	e.log.Infof("Deleting raid bdev %s before restoration", e.Name)
-	if _, err := spdkClient.BdevRaidDelete(e.Name); err != nil && !jsonrpc.IsJSONRPCRespErrorNoSuchDevice(err) {
-		return nil, errors.Wrapf(err, "failed to delete raid bdev %s before restoration", e.Name)
+	isFullRestore, err := e.backupRestorePrepare(spdkClient, backupUrl, credential, superiorPortAllocator)
+	if err != nil {
+		return resp, nil, err
 	}
 
-	e.log.Info("Disconnecting all replicas before restoration")
-	for replicaName, replicaStatus := range e.ReplicaStatusMap {
-		if err := disconnectNVMfBdev(spdkClient, replicaStatus.BdevName, disconnectMaxRetries, disconnectRetryInterval); err != nil {
-			e.log.Infof("Failed to remove replica %s before restoration", replicaName)
-			return nil, errors.Wrapf(err, "failed to remove replica %s before restoration", replicaName)
+	lastRestored := e.restore.LastRestored
+
+	defer func() {
+		if err != nil {
+			e.IsRestoring = false
+			e.Endpoint = ""
 		}
-		replicaStatus.BdevName = ""
+	}()
+
+	// The frontend (NVMe-TCP initiator) is managed by EngineFrontend.
+	// Store the provided endpoint so EngineRestore.OpenVolumeDev can access the block device.
+	// Also copy it into e.restore.endpoint so OpenVolumeDev does not need to re-acquire the
+	// engine lock (which would deadlock — BackupRestore already holds e.Lock()).
+	e.log.Infof("Using endpoint %v for backup restore", endpoint)
+	e.restore.endpoint = endpoint
+
+	// Start the backup restore. The goroutine is launched only after these calls
+	// succeed so that a failure here does not leave completeBackupRestore blocked
+	// forever in waitForRestoreComplete (goroutine leak).
+	if isFullRestore {
+		e.log.Infof("Starting a new full restore for backup %v", backupUrl)
+		if err := e.backupRestore(backupUrl, concurrentLimit); err != nil {
+			return resp, nil, errors.Wrapf(err, "failed to start full backup restore")
+		}
+		e.log.Infof("Successfully initiated full restore for %v to %v", backupUrl, e.Name)
+	} else {
+		e.log.Infof("Starting an incremental restore for backup %v", backupUrl)
+		if err := e.backupRestoreIncrementally(backupUrl, lastRestored, concurrentLimit); err != nil {
+			return resp, nil, errors.Wrapf(err, "failed to start incremental backup restore")
+		}
+		e.log.Infof("Successfully initiated incremental restore for %v to %v", backupUrl, e.Name)
+	}
+
+	// ch is closed when completeBackupRestore finishes (success, error, or cancel).
+	// The caller (EngineFrontend) waits on this channel before tearing down the initiator.
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		e.log.WithFields(logrus.Fields{
+			"snapshotName": backupInfo.SnapshotName,
+			"endpoint":     endpoint,
+		}).Info("Waiting for replica restore completion in background")
+		if err := e.completeBackupRestore(spdkClient, backupInfo.SnapshotName); err != nil {
+			e.log.WithError(err).Warn("Failed to complete backup restore")
+			return
+		}
+		e.log.WithField("snapshotName", backupInfo.SnapshotName).Info("Background backup restore completion finished")
+	}()
+
+	return resp, ch, nil
+}
+
+func (e *Engine) precheckBackupRestore(backupURL string) error {
+	if len(e.ReplicaStatusMap) == 0 {
+		return fmt.Errorf("cannot restore backup %s: no replicas available", backupURL)
+	}
+
+	for _, replicaStatus := range e.ReplicaStatusMap {
+		if replicaStatus.Mode != types.ModeRW {
+			return fmt.Errorf("cannot restore backup %s: replica %s is in mode %v",
+				backupURL, replicaStatus.Address, replicaStatus.Mode)
+		}
+	}
+
+	if e.IsRestoring {
+		return fmt.Errorf("%w", ErrRestoringInProgress)
+	}
+
+	return nil
+}
+
+func (e *Engine) backupRestorePrepare(spdkClient *spdkclient.Client, backupUrl string, credential map[string]string, superiorPortAllocator *commonbitmap.Bitmap) (isFullRestore bool, err error) {
+	backupType, err := butil.CheckBackupType(backupUrl)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to check backup type for %v", backupUrl)
+	}
+	if err = butil.SetupCredential(backupType, credential); err != nil {
+		return false, errors.Wrapf(err, "failed to setup credential for %v", backupUrl)
+	}
+
+	backupName, _, _, err := backupstore.DecodeBackupURL(util.UnescapeURL(backupUrl))
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to decode backup URL %v", backupUrl)
+	}
+
+	if e.restore == nil || e.restore.State == btypes.ProgressStateError || e.restore.State == btypes.ProgressStateCanceled {
+		e.restore = NewEngineRestore(spdkClient, backupUrl, backupName, e, superiorPortAllocator)
+	} else {
+		if e.restore.LastRestored == backupName {
+			return false, fmt.Errorf("already restored backup %v", backupName)
+		}
+		validLastRestoredBackup := e.canDoIncrementalRestore(e.restore, backupUrl, backupName)
+		e.restore.StartNewRestore(backupUrl, backupName, validLastRestoredBackup)
 	}
 
 	e.IsRestoring = true
+	e.log.WithFields(logrus.Fields{
+		"replicas":        len(e.ReplicaStatusMap),
+		"requestedBackup": backupUrl,
+		"lastRestored":    e.restore.LastRestored,
+	}).Info("Engine marked as restoring")
 
-	switch {
-	case snapshotName != "":
-		e.RestoringSnapshotName = snapshotName
-		e.log.Infof("Using input snapshot name %s for the restore", e.RestoringSnapshotName)
-	case len(e.SnapshotMap) == 0:
-		e.RestoringSnapshotName = util.UUID()
-		e.log.Infof("Using new generated snapshot name %s for the full restore", e.RestoringSnapshotName)
-	case e.RestoringSnapshotName != "":
-		e.log.Infof("Using existing snapshot name %s for the incremental restore", e.RestoringSnapshotName)
-	default:
-		e.RestoringSnapshotName = util.UUID()
-		e.log.Infof("Using new generated snapshot name %s for the incremental restore because e.FinalSnapshotName is empty", e.RestoringSnapshotName)
-	}
-
-	defer func() {
-		go func() {
-			if err := e.completeBackupRestore(spdkClient); err != nil {
-				e.log.WithError(err).Warn("Failed to complete backup restore")
-			}
-		}()
-	}()
-
-	for replicaName, replicaStatus := range e.ReplicaStatusMap {
-		e.log.Infof("Restoring backup on replica %s address %s", replicaName, replicaStatus.Address)
-
-		replicaServiceCli, err := GetServiceClient(replicaStatus.Address)
-		if err != nil {
-			e.log.WithError(err).Errorf("Failed to restore backup on replica %s with address %s", replicaName, replicaStatus.Address)
-			resp.Errors[replicaStatus.Address] = err.Error()
-			continue
-		}
-
-		func() {
-			defer func() {
-				if errClose := replicaServiceCli.Close(); errClose != nil {
-					e.log.WithError(errClose).Errorf("Failed to close replica %s client with address %s during restore backup", replicaName, replicaStatus.Address)
-				}
-			}()
-
-			err = replicaServiceCli.ReplicaBackupRestore(&client.BackupRestoreRequest{
-				BackupUrl:       backupUrl,
-				ReplicaName:     replicaName,
-				SnapshotName:    e.RestoringSnapshotName,
-				Credential:      credential,
-				ConcurrentLimit: concurrentLimit,
-			})
-			if err != nil {
-				e.log.WithError(err).Errorf("Failed to restore backup on replica %s address %s", replicaName, replicaStatus.Address)
-				resp.Errors[replicaStatus.Address] = err.Error()
-			}
-		}()
-	}
-
-	return resp, nil
+	isFullRestore = e.restore.LastRestored == ""
+	return isFullRestore, nil
 }
 
-func (e *Engine) completeBackupRestore(spdkClient *spdkclient.Client) error {
-	if err := e.waitForRestoreComplete(); err != nil {
-		return errors.Wrapf(err, "failed to wait for restore complete")
+func (e *Engine) canDoIncrementalRestore(restore *EngineRestore, backupURL, requestedBackupName string) bool {
+	if restore.LastRestored == "" {
+		e.log.Warnf("There is a restore record but last restored backup is empty with restore state %v, will do full restore instead", restore.State)
+		return false
+	}
+	if _, err := backupstore.InspectBackup(strings.Replace(backupURL, requestedBackupName, restore.LastRestored, 1)); err != nil {
+		e.log.WithError(err).Warnf("The last restored backup %v becomes invalid for incremental restore, will do full restore instead", restore.LastRestored)
+		return false
+	}
+	return true
+}
+
+func (e *Engine) backupRestore(backupURL string, concurrentLimit int32) error {
+	backupURL = butil.UnescapeURL(backupURL)
+
+	e.log.WithFields(logrus.Fields{
+		"backupURL":       backupURL,
+		"concurrentLimit": concurrentLimit,
+	}).Info("Starting full backup restore")
+
+	return backupstore.RestoreDeltaBlockBackup(e.ctx, &backupstore.DeltaRestoreConfig{
+		BackupURL:       backupURL,
+		DeltaOps:        e.restore,
+		Filename:        "",
+		ConcurrentLimit: concurrentLimit,
+	})
+}
+
+func (e *Engine) backupRestoreIncrementally(backupURL, lastRestored string, concurrentLimit int32) error {
+	backupURL = butil.UnescapeURL(backupURL)
+
+	e.log.WithFields(logrus.Fields{
+		"backupURL":       backupURL,
+		"lastRestored":    lastRestored,
+		"concurrentLimit": concurrentLimit,
+	}).Info("Starting incremental backup restore")
+
+	return backupstore.RestoreDeltaBlockBackupIncrementally(e.ctx, &backupstore.DeltaRestoreConfig{
+		BackupURL:       backupURL,
+		DeltaOps:        e.restore,
+		LastBackupName:  lastRestored,
+		Filename:        "",
+		ConcurrentLimit: concurrentLimit,
+	})
+}
+
+func (e *Engine) completeBackupRestore(spdkClient *spdkclient.Client, backupSnapshotName string) (err error) {
+	// waitForRestoreComplete only reads e.restore fields under e.restore.RLock;
+	// no engine lock is needed (and must not be held — SnapshotCreate/Delete acquire it).
+	waitErr := e.waitForRestoreComplete()
+
+	// Acquire the engine lock to mutate shared fields and tear down the temporary
+	// NVMe-TCP target. This runs regardless of success or failure so that the target
+	// is always stopped and the port always released.
+	// The EngineFrontend initiator is still connected at this point;
+	// it will be torn down after doneCh is closed (i.e. after this function returns).
+	e.Lock()
+	e.log.Infof("Finalizing backup restore state")
+
+	if !e.IsRestoring {
+		e.Unlock()
+		return fmt.Errorf("BUG: engine is not being restored")
 	}
 
-	return e.BackupRestoreFinish(spdkClient)
+	isCanceled := e.restore != nil && e.restore.State == btypes.ProgressStateCanceled
+
+	// Snapshot name recorded by a previous restore cycle (used below once the lock is dropped).
+	oldSnapshotName := ""
+	if e.restore != nil {
+		oldSnapshotName = e.restore.SnapshotName
+	}
+
+	// Clear the endpoint; the EngineFrontend will tear down the initiator after doneCh closes.
+	e.Endpoint = ""
+
+	// Stop the temporary NVMe-TCP target and release its port.
+	if e.Frontend == types.FrontendEmpty {
+		e.cleanupTemporaryNvmeTcpTargetForRestoreLocked(spdkClient, e.restore.superiorPortAllocator, "backup restore completion")
+	}
+
+	e.Unlock()
+
+	if waitErr != nil {
+		e.Lock()
+		e.IsRestoring = false
+		if e.restore != nil {
+			e.restore.UpdateRestoreStatus(e.restore.SnapshotName, 0, waitErr)
+		}
+		e.Unlock()
+		return errors.Wrapf(waitErr, "failed to wait for engine restore complete")
+	}
+
+	// Finalize restore state under the engine lock after snapshot operations complete.
+	defer func() {
+		e.Lock()
+		e.IsRestoring = false
+		if e.restore != nil {
+			if err != nil {
+				e.restore.UpdateRestoreStatus(e.restore.SnapshotName, 0, err)
+			} else {
+				e.restore.FinishRestore()
+			}
+		}
+		e.Unlock()
+	}()
+
+	if isCanceled {
+		e.log.Info("Doing nothing for canceled backup restoration")
+		return nil
+	}
+
+	// Delete previous snapshot after restore if it exists.
+	// SnapshotDelete acquires e.Lock() internally.
+	if oldSnapshotName != "" {
+		e.RLock()
+		_, snapshotExists := e.SnapshotMap[oldSnapshotName]
+		e.RUnlock()
+		if snapshotExists {
+			e.log.Infof("Deleting existing snapshot %v of the restored volume", oldSnapshotName)
+			if delErr := e.SnapshotDelete(spdkClient, oldSnapshotName); delErr != nil {
+				e.log.WithError(delErr).Warnf("Failed to delete existing snapshot %v of the restored volume", oldSnapshotName)
+			}
+		}
+	}
+
+	// Prefer using the backup source snapshot name for better traceability.
+	// Fall back to a UUID-based name if it is not available.
+	// SnapshotCreate acquires e.Lock() internally.
+	var newSnapshotName string
+	if backupSnapshotName == "" {
+		newSnapshotName = fmt.Sprintf("restore-%s", util.UUID())
+	} else {
+		newSnapshotName = fmt.Sprintf("restore-%s", backupSnapshotName)
+
+		// Avoid conflict if the snapshot already exists.
+		e.RLock()
+		_, exists := e.SnapshotMap[newSnapshotName]
+		e.RUnlock()
+		if exists {
+			suffix := util.UUID()[:5]
+			e.log.Warnf("Snapshot %v already exists, generating a unique restored snapshot name", newSnapshotName)
+			newSnapshotName = fmt.Sprintf("restore-%s-%s", backupSnapshotName, suffix)
+		}
+	}
+
+	e.log.Infof("Creating snapshot %v for the restored volume", newSnapshotName)
+	if _, createErr := e.SnapshotCreate(spdkClient, newSnapshotName); createErr != nil {
+		e.log.WithError(createErr).Warnf("Failed to create snapshot %v for the restored volume", newSnapshotName)
+	}
+
+	e.restore.Lock()
+	e.restore.SnapshotName = newSnapshotName
+	e.restore.Unlock()
+	e.log.Infof("Successfully created restored snapshot %v", newSnapshotName)
+
+	return nil
+}
+
+func (e *Engine) cleanupTemporaryNvmeTcpTargetForRestore(spdkClient *spdkclient.Client, superiorPortAllocator *commonbitmap.Bitmap, reason string) {
+	e.Lock()
+	defer e.Unlock()
+	e.cleanupTemporaryNvmeTcpTargetForRestoreLocked(spdkClient, superiorPortAllocator, reason)
+}
+
+func (e *Engine) cleanupTemporaryNvmeTcpTargetForRestoreLocked(spdkClient *spdkclient.Client, superiorPortAllocator *commonbitmap.Bitmap, reason string) {
+	if e.Frontend != types.FrontendEmpty || e.NvmeTcpTarget == nil {
+		return
+	}
+
+	if e.NvmeTcpTarget.Nqn != "" {
+		e.log.Infof("Cleaning up temporary NVMe-TCP target %s after %s", e.NvmeTcpTarget.Nqn, reason)
+		if stopErr := spdkClient.StopExposeBdev(e.NvmeTcpTarget.Nqn); stopErr != nil && !jsonrpc.IsJSONRPCRespErrorNoSuchDevice(stopErr) {
+			e.log.WithError(stopErr).Warnf("Failed to stop exposing bdev during %s", reason)
+		}
+	}
+
+	e.NvmeTcpTarget.Nqn = ""
+	e.NvmeTcpTarget.Nguid = ""
+	e.NvmeTcpTarget.IP = ""
+	if relErr := e.releasePorts(superiorPortAllocator); relErr != nil {
+		e.log.WithError(relErr).Warnf("Failed to release ports during %s", reason)
+	}
 }
 
 func (e *Engine) waitForRestoreComplete() error {
-	periodicChecker := time.NewTicker(time.Duration(restorePeriodicRefreshInterval.Seconds()) * time.Second)
-	defer periodicChecker.Stop()
+	e.log.WithFields(logrus.Fields{
+		"interval":     restorePeriodicRefreshInterval.String(),
+		"snapshotName": e.RestoringSnapshotName,
+	}).Info("Waiting for restore to complete")
 
-	var err error
-	for range periodicChecker.C {
-		isReplicaRestoreCompleted := true
-		for replicaName, replicaStatus := range e.ReplicaStatusMap {
-			if replicaStatus.Mode != types.ModeRW {
-				continue
+	err := retrygo.Do(
+		func() error {
+			e.restore.RLock()
+			restoreProgress := e.restore.Progress
+			restoreError := e.restore.Error
+			restoreState := e.restore.State
+			e.restore.RUnlock()
+
+			if restoreState == btypes.ProgressStateCanceled {
+				return retrygo.Unrecoverable(fmt.Errorf("%v", btypes.ErrorMsgRestoreCancelled))
+			}
+			if restoreProgress == 100 {
+				e.log.Infof("Backup restore is done: %v%%", restoreProgress)
+				return nil
 			}
 
-			isReplicaRestoreCompleted, err = e.isReplicaRestoreCompleted(replicaName, replicaStatus.Address)
-			if err != nil {
-				return errors.Wrapf(err, "failed to check replica %s restore status", replicaName)
+			e.log.WithFields(logrus.Fields{
+				"progress":     restoreProgress,
+				"state":        restoreState,
+				"snapshotName": e.RestoringSnapshotName,
+			}).Debug("Restore is still in progress")
+
+			if restoreError != "" {
+				err := fmt.Errorf("%v", restoreError)
+				e.log.WithError(err).Error("Found backup restoration error")
+				return retrygo.Unrecoverable(err)
 			}
 
-			if !isReplicaRestoreCompleted {
-				break
-			}
-		}
+			return fmt.Errorf("restore is still in progress")
+		},
+		retrygo.Delay(restorePeriodicRefreshInterval),
+		retrygo.MaxDelay(restorePeriodicRefreshInterval),
+		retrygo.DelayType(retrygo.FixedDelay),
+		retrygo.Attempts(0), // retry forever until success or unrecoverable error
+	)
 
-		if isReplicaRestoreCompleted {
-			e.log.Info("Backup restoration completed successfully")
-			return nil
-		}
-	}
-
-	return errors.Errorf("failed to wait for engine %s restore complete", e.Name)
-}
-
-func (e *Engine) isReplicaRestoreCompleted(replicaName, replicaAddress string) (bool, error) {
-	log := e.log.WithFields(logrus.Fields{
-		"replica": replicaName,
-		"address": replicaAddress,
-	})
-	log.Trace("Checking replica restore status")
-
-	replicaServiceCli, err := GetServiceClient(replicaAddress)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to get replica %v service client %s", replicaName, replicaAddress)
+		return err
 	}
-	defer func() {
-		if errClose := replicaServiceCli.Close(); errClose != nil {
-			log.WithError(errClose).Errorf("Failed to close replica %s client with address %s during check restore status", replicaName, replicaAddress)
-		}
-	}()
-
-	status, err := replicaServiceCli.ReplicaRestoreStatus(replicaName)
-	if err != nil {
-		return false, errors.Wrapf(err, "failed to check replica %s restore status", replicaName)
-	}
-
-	return !status.IsRestoring, nil
-}
-
-func (e *Engine) BackupRestoreFinish(spdkClient *spdkclient.Client) error {
-	updateRequired := false
-
-	e.Lock()
-	defer func() {
-		e.Unlock()
-		if updateRequired {
-			e.UpdateCh <- nil
-		}
-	}()
-
-	replicaBdevList := []string{}
-	for replicaName, replicaStatus := range e.ReplicaStatusMap {
-		replicaAddress := replicaStatus.Address
-		replicaIP, replicaPort, err := net.SplitHostPort(replicaAddress)
-		if err != nil {
-			return err
-		}
-		e.log.Infof("Attaching replica %s with address %s before finishing restoration", replicaName, replicaAddress)
-		replicaAdrfam := spdkclient.DetectAddressFamily(replicaIP)
-		nvmeBdevNameList, err := spdkClient.BdevNvmeAttachController(replicaName, helpertypes.GetNQN(replicaName), replicaIP, replicaPort,
-			spdktypes.NvmeTransportTypeTCP, replicaAdrfam,
-			int32(e.ctrlrLossTimeout), replicaReconnectDelaySec, int32(e.fastIOFailTimeoutSec), replicaMultipath)
-		if err != nil {
-			return err
-		}
-
-		if len(nvmeBdevNameList) != 1 {
-			return fmt.Errorf("got unexpected nvme bdev list %v", nvmeBdevNameList)
-		}
-
-		replicaStatus.BdevName = nvmeBdevNameList[0]
-		replicaStatus.Mode = types.ModeRW
-
-		replicaBdevList = append(replicaBdevList, replicaStatus.BdevName)
-	}
-
-	e.log.Infof("Creating raid bdev %s with replicas %+v before finishing restoration", e.Name, replicaBdevList)
-	if _, err := spdkClient.BdevRaidCreate(e.Name, spdktypes.BdevRaidLevel1, 0, replicaBdevList, ""); err != nil {
-		if !jsonrpc.IsJSONRPCRespErrorFileExists(err) {
-			e.log.WithError(err).Errorf("Failed to create raid bdev before finishing restoration")
-			return err
-		}
-	}
-
-	e.IsRestoring = false
-	e.checkAndUpdateInfoFromReplicasNoLock()
-	updateRequired = true
 
 	return nil
 }
@@ -2265,41 +2456,44 @@ func (e *Engine) RestoreStatus() (*spdkrpc.RestoreStatusResponse, error) {
 		Status: map[string]*spdkrpc.ReplicaRestoreStatusResponse{},
 	}
 
-	e.Lock()
-	defer e.Unlock()
+	e.RLock()
+	defer e.RUnlock()
+
+	if e.restore == nil {
+		for replicaName, replicaStatus := range e.ReplicaStatusMap {
+			resp.Status[replicaStatus.Address] = &spdkrpc.ReplicaRestoreStatusResponse{
+				ReplicaName:    replicaName,
+				ReplicaAddress: GetBackendReplicaURL(replicaStatus.Address),
+				IsRestoring:    false,
+			}
+		}
+		return resp, nil
+	}
+
+	e.restore.RLock()
+	restoreProgress := e.restore.Progress
+	restoreError := e.restore.Error
+	restoreState := e.restore.State
+	lastRestored := e.restore.LastRestored
+	currentRestoringBackup := e.restore.CurrentRestoringBackup
+	backupURL := e.restore.BackupURL
+	e.restore.RUnlock()
 
 	for replicaName, replicaStatus := range e.ReplicaStatusMap {
-		if replicaStatus.Mode != types.ModeRW {
-			continue
+		resp.Status[replicaStatus.Address] = &spdkrpc.ReplicaRestoreStatusResponse{
+			ReplicaName:            replicaName,
+			ReplicaAddress:         GetBackendReplicaURL(replicaStatus.Address),
+			IsRestoring:            e.IsRestoring,
+			LastRestored:           lastRestored,
+			Progress:               int32(restoreProgress),
+			Error:                  restoreError,
+			State:                  string(restoreState),
+			BackupUrl:              backupURL,
+			CurrentRestoringBackup: currentRestoringBackup,
 		}
-
-		restoreStatus, err := e.getReplicaRestoreStatus(replicaName, replicaStatus.Address)
-		if err != nil {
-			return nil, err
-		}
-		resp.Status[replicaStatus.Address] = restoreStatus
 	}
 
 	return resp, nil
-}
-
-func (e *Engine) getReplicaRestoreStatus(replicaName, replicaAddress string) (*spdkrpc.ReplicaRestoreStatusResponse, error) {
-	replicaServiceCli, err := GetServiceClient(replicaAddress)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if errClose := replicaServiceCli.Close(); errClose != nil {
-			e.log.WithError(errClose).Errorf("Failed to close replica client with address %s during get restore status", replicaAddress)
-		}
-	}()
-
-	status, err := replicaServiceCli.ReplicaRestoreStatus(replicaName)
-	if err != nil {
-		return nil, err
-	}
-
-	return status, nil
 }
 
 // Expand performs an online volume expansion for the Longhorn Engine using SPDK.
@@ -3261,4 +3455,32 @@ func (e *Engine) SetReplicaAddFinishUnlockedHook(hook func()) {
 	e.Lock()
 	defer e.Unlock()
 	e.replicaAddFinishUnlockedHook = hook
+}
+
+func GetBackendReplicaURL(address string) string {
+	return "tcp://" + address
+}
+
+// ensureNvmeTcpTargetForRestore creates a temporary NVMe-TCP target if the engine does not
+// already have one (e.g. engines with Frontend = ""). Called by EngineFrontend before
+// connecting its restore initiator so that the target address is available.
+func (e *Engine) ensureNvmeTcpTargetForRestore(spdkClient *spdkclient.Client, superiorPortAllocator *commonbitmap.Bitmap) error {
+	e.Lock()
+	defer e.Unlock()
+
+	if e.NvmeTcpTarget.IP != "" && e.NvmeTcpTarget.Port != 0 {
+		return nil // target already present (e.g. from a prior partial restore attempt)
+	}
+
+	e.log.Info("Creating temporary NVMe-TCP target for backup restore")
+	if err := e.createNVMeTCPTarget(spdkClient, superiorPortAllocator, 1, NvmeTCPANAStateOptimized); err != nil {
+		if relErr := e.releasePorts(superiorPortAllocator); relErr != nil {
+			e.log.WithError(relErr).Warn("Failed to release ports after temporary NVMe-TCP target creation failure")
+		}
+		e.NvmeTcpTarget.IP = ""
+		e.NvmeTcpTarget.Nguid = ""
+		e.NvmeTcpTarget.Nqn = ""
+		return errors.Wrap(err, "failed to create temporary NVMe-TCP target for backup restore")
+	}
+	return nil
 }

--- a/pkg/spdk/enginefrontend.go
+++ b/pkg/spdk/enginefrontend.go
@@ -19,6 +19,7 @@ import (
 	"github.com/longhorn/longhorn-spdk-engine/pkg/types"
 	"github.com/longhorn/longhorn-spdk-engine/pkg/util"
 
+	commonbitmap "github.com/longhorn/go-common-libs/bitmap"
 	safelog "github.com/longhorn/longhorn-spdk-engine/pkg/log"
 
 	"github.com/longhorn/go-spdk-helper/pkg/initiator"
@@ -2660,5 +2661,124 @@ func (ef *EngineFrontend) RecoverFromHost(spdkClient *spdkclient.Client) error {
 	default:
 		recoverErr = fmt.Errorf("unsupported frontend type %s for recovery of engine frontend %s", ef.Frontend, ef.Name)
 		return recoverErr
+	}
+}
+
+// BackupRestore initiates a backup restore via this frontend.
+// The EngineFrontend must not have an active endpoint — it is expected to be a
+// dedicated restore frontend with no pre-existing initiator connection.
+// A temporary NVMe-TCP target is created on the engine for data transfer and torn
+// down (along with the initiator) once the restore goroutine completes.
+// Flow: EngineFrontend.BackupRestore -> Engine.BackupRestore
+func (ef *EngineFrontend) BackupRestore(engine *Engine, spdkClient *spdkclient.Client, backupUrl string, credential map[string]string, concurrentLimit int32, superiorPortAllocator *commonbitmap.Bitmap) (resp *spdkrpc.EngineBackupRestoreResponse, err error) {
+	ef.log.Infof("Starting backup restore for backup %s", backupUrl)
+	targetPrepared := false
+	frontendPrepared := false
+
+	ef.Lock()
+	if ef.isCreating {
+		ef.Unlock()
+		return nil, fmt.Errorf("engine frontend %s is still creating", ef.Name)
+	}
+	if ef.isSwitchingOver {
+		ef.Unlock()
+		return nil, fmt.Errorf("engine frontend %s is switching over target", ef.Name)
+	}
+	if ef.Endpoint != "" {
+		ef.Unlock()
+		return nil, fmt.Errorf("engine frontend %s already has an active endpoint %s; backup restore requires a dedicated frontend with no existing connection", ef.Name, ef.Endpoint)
+	}
+	ef.IsRestoring = true
+	ef.Frontend = types.FrontendSPDKTCPBlockdev
+	ef.Unlock()
+
+	defer func() {
+		if err != nil {
+			if targetPrepared {
+				engine.cleanupTemporaryNvmeTcpTargetForRestore(spdkClient, superiorPortAllocator, "restore flow failure")
+			}
+			if frontendPrepared {
+				ef.teardownRestoreInitiator(spdkClient)
+			}
+			ef.Lock()
+			ef.IsRestoring = false
+			ef.Frontend = ""
+			ef.Unlock()
+		} else {
+			ef.UpdateCh <- nil
+		}
+	}()
+
+	// Ensure the engine has a NVMe-TCP target to connect to (creates one if absent).
+	if err := engine.ensureNvmeTcpTargetForRestore(spdkClient, superiorPortAllocator); err != nil {
+		return nil, errors.Wrapf(err, "engine %s: failed to ensure NVMe-TCP target for backup restore", engine.Name)
+	}
+	targetPrepared = true
+
+	engine.RLock()
+	targetAddress := net.JoinHostPort(engine.NvmeTcpTarget.IP, strconv.Itoa(int(engine.NvmeTcpTarget.Port)))
+	engine.RUnlock()
+
+	ef.log.Infof("Setting up NVMe-TCP initiator for backup restore, target: %s", targetAddress)
+	if err := ef.createNvmeTcpFrontend(spdkClient, targetAddress); err != nil {
+		return nil, errors.Wrapf(err, "failed to setup NVMe-TCP frontend for backup restore")
+	}
+	frontendPrepared = true
+
+	ef.RLock()
+	endpoint := ef.Endpoint
+	ef.RUnlock()
+
+	if endpoint == "" {
+		return nil, fmt.Errorf("engine frontend %s has no endpoint after frontend setup for backup restore", ef.Name)
+	}
+
+	ef.log.Infof("Using endpoint %s for backup restore", endpoint)
+	resp, doneCh, err := engine.BackupRestore(spdkClient, backupUrl, endpoint, credential, concurrentLimit, superiorPortAllocator)
+	if err != nil {
+		return nil, err
+	}
+
+	// Tear down the initiator connection once the restore goroutine signals completion.
+	go func() {
+		<-doneCh
+		ef.log.Info("Backup restore complete, tearing down NVMe-TCP frontend")
+		ef.teardownRestoreInitiator(spdkClient)
+
+		ef.Lock()
+		ef.IsRestoring = false
+		ef.Unlock()
+		ef.UpdateCh <- nil
+	}()
+
+	return resp, nil
+}
+
+func (ef *EngineFrontend) teardownRestoreInitiator(spdkClient *spdkclient.Client) {
+	ef.Lock()
+	defer ef.Unlock()
+
+	if ef.initiator != nil {
+		if _, stopErr := ef.initiator.Stop(spdkClient, true, true, true); stopErr != nil {
+			ef.log.WithError(stopErr).Warn("Failed to stop NVMe-TCP initiator after backup restore")
+		}
+		ef.initiator = nil
+	}
+	ef.Endpoint = ""
+	ef.Frontend = ""
+
+	if ef.NvmeTcpFrontend != nil {
+		ef.NvmeTcpFrontend.TargetIP = ""
+		ef.NvmeTcpFrontend.TargetPort = 0
+		ef.NvmeTcpFrontend.Nqn = ""
+		ef.NvmeTcpFrontend.Nguid = ""
+	}
+
+	// The restore frontend is only a temporary data path. Once it is torn down,
+	// report the frontend as stopped so the control plane can recreate a normal
+	// attach frontend instead of treating this now-empty process as still ready.
+	if ef.State != types.InstanceStateError {
+		ef.State = types.InstanceStateStopped
+		ef.ErrorMsg = ""
 	}
 }

--- a/pkg/spdk/restore.go
+++ b/pkg/spdk/restore.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/longhorn/backupstore"
-
 	"github.com/longhorn/go-spdk-helper/pkg/initiator"
 
 	btypes "github.com/longhorn/backupstore/types"

--- a/pkg/spdk/restore_engine.go
+++ b/pkg/spdk/restore_engine.go
@@ -1,0 +1,167 @@
+package spdk
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/cockroachdb/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/longhorn/backupstore"
+
+	btypes "github.com/longhorn/backupstore/types"
+	commonbitmap "github.com/longhorn/go-common-libs/bitmap"
+	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
+)
+
+type EngineRestore struct {
+	sync.RWMutex
+
+	spdkClient *spdkclient.Client
+	engine     *Engine
+	endpoint   string
+
+	Progress  int
+	Error     string
+	BackupURL string
+	State     btypes.ProgressState
+
+	// The snapshot file that stores the restored data in the end.
+	SnapshotName string
+
+	superiorPortAllocator *commonbitmap.Bitmap
+
+	LastRestored           string
+	CurrentRestoringBackup string
+
+	stopChan chan struct{}
+	stopOnce sync.Once
+
+	log logrus.FieldLogger
+}
+
+var _ backupstore.DeltaRestoreOperations = (*EngineRestore)(nil)
+
+func NewEngineRestore(spdkClient *spdkclient.Client, backupURL string, backupName string, engine *Engine, superiorPortAllocator *commonbitmap.Bitmap) *EngineRestore {
+	log := logrus.WithFields(logrus.Fields{
+		"backupURL":  backupURL,
+		"backupName": backupName,
+	})
+
+	return &EngineRestore{
+		spdkClient:             spdkClient,
+		engine:                 engine,
+		BackupURL:              backupURL,
+		CurrentRestoringBackup: backupName,
+		superiorPortAllocator:  superiorPortAllocator,
+		State:                  btypes.ProgressStateInProgress,
+		Progress:               0,
+		stopChan:               make(chan struct{}),
+		log:                    log,
+	}
+}
+
+func (r *EngineRestore) StartNewRestore(backupURL string, currentRestoringBackup string, validLastRestoredBackup bool) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Progress = 0
+	r.Error = ""
+	r.BackupURL = backupURL
+	r.State = btypes.ProgressStateInProgress
+
+	if !validLastRestoredBackup {
+		r.LastRestored = ""
+	}
+
+	r.CurrentRestoringBackup = currentRestoringBackup
+}
+
+func (r *EngineRestore) DeepCopy() *EngineRestore {
+	r.RLock()
+	defer r.RUnlock()
+
+	return &EngineRestore{
+		BackupURL:              r.BackupURL,
+		CurrentRestoringBackup: r.CurrentRestoringBackup,
+		LastRestored:           r.LastRestored,
+		SnapshotName:           r.SnapshotName,
+		superiorPortAllocator:  r.superiorPortAllocator,
+		State:                  r.State,
+		Error:                  r.Error,
+		Progress:               r.Progress,
+	}
+}
+
+func (r *EngineRestore) OpenVolumeDev(_ string) (*os.File, string, error) {
+	endpoint := r.endpoint
+
+	r.log.Infof("Opening NVMe device %v", endpoint)
+	fh, err := os.OpenFile(endpoint, os.O_RDWR|syscall.O_DIRECT, 0666)
+	if err != nil {
+		return nil, "", errors.Wrapf(err, "failed to open NVMe device %v", endpoint)
+	}
+	return fh, endpoint, nil
+}
+
+func (r *EngineRestore) CloseVolumeDev(volDev *os.File) error {
+	if err := volDev.Sync(); err != nil {
+		r.log.WithError(err).Errorf("Failed to sync NVMe device %v before close", volDev.Name())
+	}
+
+	r.log.Infof("Closing NVMe device %v", volDev.Name())
+	closeErr := volDev.Close()
+
+	return closeErr
+}
+
+func (r *EngineRestore) UpdateRestoreStatus(snapshot string, progress int, err error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Progress = progress
+
+	if err != nil {
+		if strings.Contains(err.Error(), btypes.ErrorMsgRestoreCancelled) {
+			r.State = btypes.ProgressStateCanceled
+			r.Error = err.Error()
+		} else {
+			r.State = btypes.ProgressStateError
+			if r.Error != "" {
+				r.Error = fmt.Sprintf("%v: %v", err.Error(), r.Error)
+			} else {
+				r.Error = err.Error()
+			}
+		}
+	}
+}
+
+func (r *EngineRestore) FinishRestore() {
+	r.Lock()
+	defer r.Unlock()
+
+	if r.State != btypes.ProgressStateError && r.State != btypes.ProgressStateCanceled {
+		r.State = btypes.ProgressStateComplete
+		r.LastRestored = r.CurrentRestoringBackup
+		r.CurrentRestoringBackup = ""
+	}
+}
+
+func (r *EngineRestore) Stop() {
+	r.stopOnce.Do(func() {
+		close(r.stopChan)
+
+		r.Lock()
+		defer r.Unlock()
+		r.State = btypes.ProgressStateCanceled
+		r.Error = btypes.ErrorMsgRestoreCancelled
+		r.Progress = 0
+	})
+}
+
+func (r *EngineRestore) GetStopChan() chan struct{} {
+	return r.stopChan
+}

--- a/pkg/spdk/server_engine.go
+++ b/pkg/spdk/server_engine.go
@@ -540,22 +540,74 @@ func (s *Server) EngineBackupStatus(ctx context.Context, req *spdkrpc.BackupStat
 
 func (s *Server) EngineBackupRestore(ctx context.Context, req *spdkrpc.EngineBackupRestoreRequest) (ret *spdkrpc.EngineBackupRestoreResponse, err error) {
 	logrus.WithFields(logrus.Fields{
-		"backup":       req.BackupUrl,
-		"engine":       req.EngineName,
-		"snapshotName": req.SnapshotName,
-		"concurrent":   req.ConcurrentLimit,
+		"backup":     req.BackupUrl,
+		"engine":     req.EngineName,
+		"concurrent": req.ConcurrentLimit,
 	}).Info("Restoring backup")
 
 	s.RLock()
-	e := s.engineMap[req.EngineName]
-	spdkClient := s.spdkClient
-	s.RUnlock()
-
-	if e == nil {
+	e, exist := s.engineMap[req.EngineName]
+	if !exist {
+		s.RUnlock()
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find engine %v for restoring backup", req.EngineName)
 	}
 
-	return e.BackupRestore(spdkClient, req.BackupUrl, req.EngineName, req.SnapshotName, req.Credential, req.ConcurrentLimit)
+	// Backup restore is only supported when the engine has no frontend (empty EngineFrontend).
+	// Reject requests if any frontend is configured.
+	for _, frontend := range s.engineFrontendMap {
+		frontend.RLock()
+		engineName := frontend.EngineName
+		frontendType := frontend.Frontend
+		frontendName := frontend.Name
+		frontend.RUnlock()
+
+		if engineName == req.EngineName && frontendType != types.FrontendEmpty {
+			s.RUnlock()
+			return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition, "cannot restore backup: engine %v has a non-empty frontend %v", req.EngineName, frontendName)
+		}
+	}
+
+	spdkClient := s.spdkClient
+	portAllocator := s.portAllocator
+	s.RUnlock()
+
+	// Create a temporary EngineFrontend for the duration of this restore.
+	// It is NOT registered in engineFrontendMap and is discarded on return.
+	//
+	// FrontendSPDKTCPBlockdev causes BackupRestore to create an NVMe-TCP initiator
+	// and expose a block device that EngineRestore.OpenVolumeDev can open.
+	//
+	// The channel must be buffered with capacity 2: EngineFrontend.BackupRestore sends
+	// once on the success path (via defer) and the teardown goroutine sends once on
+	// completion. There is no reader, so an unbuffered channel would block both senders
+	// permanently. The buffer absorbs both sends and the channel is GC'd with tempEF.
+	e.RLock()
+	volumeName := e.VolumeName
+	specSize := e.SpecSize
+	e.RUnlock()
+
+	throwawayUpdateCh := make(chan interface{}, 2)
+	tempEF := NewEngineFrontend(
+		e.Name+"-restore",
+		e.Name,
+		volumeName,
+		types.FrontendSPDKTCPBlockdev,
+		specSize,
+		types.DefaultUblkQueueDepth,
+		types.DefaultUblkNumberOfQueue,
+		throwawayUpdateCh,
+	)
+
+	logrus.WithFields(logrus.Fields{
+		"enginefrontend": tempEF.Name,
+		"engine":         tempEF.EngineName,
+		"volume":         tempEF.VolumeName,
+		"frontend":       tempEF.Frontend,
+		"replicas":       len(e.ReplicaStatusMap),
+		"specSize":       e.SpecSize,
+	}).Info("Creating temporary engine frontend for backup restore request")
+
+	return tempEF.BackupRestore(e, spdkClient, req.BackupUrl, req.Credential, req.ConcurrentLimit, portAllocator)
 }
 
 func (s *Server) EngineRestoreStatus(ctx context.Context, req *spdkrpc.RestoreStatusRequest) (*spdkrpc.RestoreStatusResponse, error) {
@@ -564,7 +616,7 @@ func (s *Server) EngineRestoreStatus(ctx context.Context, req *spdkrpc.RestoreSt
 	s.RUnlock()
 
 	if e == nil {
-		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find engine %v for backup creation", req.EngineName)
+		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find engine %v for restore status", req.EngineName)
 	}
 
 	resp, err := e.RestoreStatus()


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/9277

#### What this PR does / why we need it:

LEP: https://github.com/longhorn/longhorn/pull/12609

#### Special notes for your reviewer:

Preserve the existing `replica.BackupRestore` implementation for future use.

#### Additional documentation or context

e2e test pass:
- negativeANDbackup
- negativeANDdr-volume
- regressionANDbackup

https://ci.longhorn.io/job/private/job/longhorn-e2e-test/6820/
https://ci.longhorn.io/job/private/job/longhorn-e2e-test/6821/
https://ci.longhorn.io/job/private/job/longhorn-e2e-test/6829/