### PR TITLE
feat(ipv6): support IPv6 and dual-stack pods for engine and replica

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jinzhu/copier v0.4.0
 	github.com/longhorn/backupstore v0.0.0-20260414054550-8570535ce7ad
 	github.com/longhorn/go-common-libs v0.0.0-20260328134226-cafa38fc4ce8
-	github.com/longhorn/go-spdk-helper v0.5.1-0.20260416023608-49b12f8b468b
+	github.com/longhorn/go-spdk-helper v0.6.1-0.20260422091955-74dd5ebcf118
 	github.com/longhorn/types v0.0.0-20260417071722-2f1958bc30e5
 	github.com/sirupsen/logrus v1.9.4
 	go.uber.org/multierr v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/longhorn/backupstore v0.0.0-20260414054550-8570535ce7ad h1:B1nZo9xIBU
 github.com/longhorn/backupstore v0.0.0-20260414054550-8570535ce7ad/go.mod h1:20Yvj7Gz9wkp1iHD1u77+CWG281L6SVe8/SZDnwQMAI=
 github.com/longhorn/go-common-libs v0.0.0-20260328134226-cafa38fc4ce8 h1:HxGyRXTDRYF7vwtaT2ESlV3ognMHolL4lBCStHXvf7o=
 github.com/longhorn/go-common-libs v0.0.0-20260328134226-cafa38fc4ce8/go.mod h1:Vw9cRchaffWmZMjHOjqhSG37tFN9DdQ/isKs4ViPXQE=
-github.com/longhorn/go-spdk-helper v0.5.1-0.20260416023608-49b12f8b468b h1:1sEBy14GJg5OgLr5SN9tyDyOTV8KS+IioZi5V7M17gg=
-github.com/longhorn/go-spdk-helper v0.5.1-0.20260416023608-49b12f8b468b/go.mod h1:Q6lpfqGmo7ZksEBuMRhzPz3J4LEKLuBebXl37374g0E=
+github.com/longhorn/go-spdk-helper v0.6.1-0.20260422091955-74dd5ebcf118 h1:RXDo8yttKgZp6QlB1wV89+EEq4rgwHF+hS1IDhQOGAA=
+github.com/longhorn/go-spdk-helper v0.6.1-0.20260422091955-74dd5ebcf118/go.mod h1:Q6lpfqGmo7ZksEBuMRhzPz3J4LEKLuBebXl37374g0E=
 github.com/longhorn/types v0.0.0-20260417071722-2f1958bc30e5 h1:kZMVXdShXQUEagwzvuayZDu5W8mpRyGI0pcHXaiTKrg=
 github.com/longhorn/types v0.0.0-20260417071722-2f1958bc30e5/go.mod h1:qLF81pbxPxRteatoPFqVjcr0FPga839D8Cj2k1V4/1c=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -413,12 +413,14 @@ func (e *Engine) SetTargetListenerANAState(spdkClient *spdkclient.Client, anaSta
 		return fmt.Errorf("engine %s has incomplete NVMe/TCP target information", e.Name)
 	}
 
+	targetAdrfam := spdkclient.DetectAddressFamily(ip)
+
 	_, err = spdkClient.NvmfSubsystemListenerSetANAState(
 		nqn,
 		ip,
 		strconv.Itoa(int(port)),
 		spdktypes.NvmeTransportTypeTCP,
-		spdktypes.NvmeAddressFamilyIPv4,
+		targetAdrfam,
 		spdkANAState,
 		spdktypes.DefaultNvmfANAGroupID,
 	)
@@ -2225,8 +2227,9 @@ func (e *Engine) BackupRestoreFinish(spdkClient *spdkclient.Client) error {
 			return err
 		}
 		e.log.Infof("Attaching replica %s with address %s before finishing restoration", replicaName, replicaAddress)
+		replicaAdrfam := spdkclient.DetectAddressFamily(replicaIP)
 		nvmeBdevNameList, err := spdkClient.BdevNvmeAttachController(replicaName, helpertypes.GetNQN(replicaName), replicaIP, replicaPort,
-			spdktypes.NvmeTransportTypeTCP, spdktypes.NvmeAddressFamilyIPv4,
+			spdktypes.NvmeTransportTypeTCP, replicaAdrfam,
 			int32(e.ctrlrLossTimeout), replicaReconnectDelaySec, int32(e.fastIOFailTimeoutSec), replicaMultipath)
 		if err != nil {
 			return err
@@ -3197,11 +3200,17 @@ func validateAndGetSingleNvmeInfo(replicaName string, bdev *spdktypes.BdevInfo) 
 }
 
 func validateNvmeTransport(replicaName, bdevName string, nvmeInfo spdktypes.NvmeNamespaceInfo) error {
-	if !strings.EqualFold(string(nvmeInfo.Trid.Adrfam), string(spdktypes.NvmeAddressFamilyIPv4)) ||
-		!strings.EqualFold(string(nvmeInfo.Trid.Trtype), string(spdktypes.NvmeTransportTypeTCP)) {
+	if !strings.EqualFold(string(nvmeInfo.Trid.Trtype), string(spdktypes.NvmeTransportTypeTCP)) {
 		return fmt.Errorf(
-			"found invalid address family %s and transport type %s in a remote NVMe base bdev %s during replica %s mode validation",
-			nvmeInfo.Trid.Adrfam, nvmeInfo.Trid.Trtype, bdevName, replicaName,
+			"found invalid transport type %s in a remote NVMe base bdev %s during replica %s mode validation",
+			nvmeInfo.Trid.Trtype, bdevName, replicaName,
+		)
+	}
+	if !strings.EqualFold(string(nvmeInfo.Trid.Adrfam), string(spdktypes.NvmeAddressFamilyIPv4)) &&
+		!strings.EqualFold(string(nvmeInfo.Trid.Adrfam), string(spdktypes.NvmeAddressFamilyIPv6)) {
+		return fmt.Errorf(
+			"found invalid address family %s in a remote NVMe base bdev %s during replica %s mode validation",
+			nvmeInfo.Trid.Adrfam, bdevName, replicaName,
 		)
 	}
 	return nil

--- a/pkg/spdk/engine_test.go
+++ b/pkg/spdk/engine_test.go
@@ -1,5 +1,76 @@
 package spdk
 
+import (
+	. "gopkg.in/check.v1"
+
+	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
+)
+
+func (s *TestSuite) TestGetExposedPort(c *C) {
+	testCases := []struct {
+		name         string
+		subsystem    spdktypes.NvmfSubsystem
+		expectedPort int32
+		expectError  bool
+	}{
+		{
+			name: "IPv4 TCP listener returns correct port",
+			subsystem: spdktypes.NvmfSubsystem{
+				ListenAddresses: []spdktypes.NvmfSubsystemListenAddress{{
+					Trtype:  spdktypes.NvmeTransportTypeTCP,
+					Adrfam:  spdktypes.NvmeAddressFamilyIPv4,
+					Trsvcid: "20001",
+				}},
+			},
+			expectedPort: 20001,
+			expectError:  false,
+		},
+		{
+			name: "IPv6 TCP listener returns correct port",
+			subsystem: spdktypes.NvmfSubsystem{
+				ListenAddresses: []spdktypes.NvmfSubsystemListenAddress{{
+					Trtype:  spdktypes.NvmeTransportTypeTCP,
+					Adrfam:  spdktypes.NvmeAddressFamilyIPv6,
+					Trsvcid: "20002",
+				}},
+			},
+			expectedPort: 20002,
+			expectError:  false,
+		},
+		{
+			name: "non-TCP listener is rejected",
+			subsystem: spdktypes.NvmfSubsystem{
+				ListenAddresses: []spdktypes.NvmfSubsystemListenAddress{{
+					Trtype:  spdktypes.NvmeTransportTypeRDMA,
+					Adrfam:  spdktypes.NvmeAddressFamilyIPv4,
+					Trsvcid: "20003",
+				}},
+			},
+			expectedPort: 0,
+			expectError:  true,
+		},
+		{
+			name: "empty listeners returns error",
+			subsystem: spdktypes.NvmfSubsystem{
+				ListenAddresses: nil,
+			},
+			expectedPort: 0,
+			expectError:  true,
+		},
+	}
+	for _, tc := range testCases {
+		c.Logf("testing getExposedPort.%s", tc.name)
+		port, err := getExposedPort(&tc.subsystem)
+		if tc.expectError {
+			c.Assert(err, NotNil, Commentf("Test case '%s': expected error", tc.name))
+		} else {
+			c.Assert(err, IsNil, Commentf("Test case '%s': unexpected error", tc.name))
+			c.Assert(port, Equals, tc.expectedPort,
+				Commentf("Test case '%s': unexpected port", tc.name))
+		}
+	}
+}
+
 //	. "gopkg.in/check.v1"
 
 // func (s *TestSuite) xxTestcheckInitiatorAndTargetCreationRequirementsForNvmeTcpFrontend(c *C) {

--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -662,8 +662,7 @@ func getExposedPort(subsystem *spdktypes.NvmfSubsystem) (exposedPort int32, err 
 
 	port := 0
 	for _, listenAddr := range subsystem.ListenAddresses {
-		if !strings.EqualFold(string(listenAddr.Adrfam), string(spdktypes.NvmeAddressFamilyIPv4)) ||
-			!strings.EqualFold(string(listenAddr.Trtype), string(spdktypes.NvmeTransportTypeTCP)) {
+		if !strings.EqualFold(string(listenAddr.Trtype), string(spdktypes.NvmeTransportTypeTCP)) {
 			continue
 		}
 		port, err = strconv.Atoi(listenAddr.Trsvcid)

--- a/pkg/spdk/util.go
+++ b/pkg/spdk/util.go
@@ -143,6 +143,7 @@ func connectNVMfBdev(spdkClient *spdkclient.Client, controllerName, address stri
 		return "", err
 	}
 
+	adrfam := spdkclient.DetectAddressFamily(ip)
 	nvmeBdevNameList := []string{}
 	err = retry.Do(
 		func() error {
@@ -153,7 +154,7 @@ func connectNVMfBdev(spdkClient *spdkclient.Client, controllerName, address stri
 				ip,
 				port,
 				spdktypes.NvmeTransportTypeTCP,
-				spdktypes.NvmeAddressFamilyIPv4,
+				adrfam,
 				int32(ctrlrLossTimeout),
 				replicaReconnectDelaySec,
 				int32(fastIOFailTimeoutSec),

--- a/pkg/spdk/util_test.go
+++ b/pkg/spdk/util_test.go
@@ -2,11 +2,15 @@ package spdk
 
 import (
 	"fmt"
+	"net"
 	"testing"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/longhorn/longhorn-spdk-engine/pkg/types"
+
+	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
+	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -145,4 +149,25 @@ func (s *TestSuite) TestSetReplicaAdderInjectsRealFallback(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Assert(secondFallback.e, Equals, e)
 	c.Assert(secondMock.Real == firstMock, Equals, false)
+}
+
+func (s *TestSuite) TestConnectNVMfBdevAdrfamDetection(c *C) {
+	testCases := []struct {
+		address        string
+		expectedIP     string
+		expectedAdrfam spdktypes.NvmeAddressFamily
+	}{
+		{"[fd00::1]:20001", "fd00::1", spdktypes.NvmeAddressFamilyIPv6},
+		{"10.0.0.1:20001", "10.0.0.1", spdktypes.NvmeAddressFamilyIPv4},
+		{"[::1]:20001", "::1", spdktypes.NvmeAddressFamilyIPv6},
+		{"192.168.1.100:8500", "192.168.1.100", spdktypes.NvmeAddressFamilyIPv4},
+	}
+	for _, tc := range testCases {
+		ip, _, err := net.SplitHostPort(tc.address)
+		c.Assert(err, IsNil)
+		c.Assert(ip, Equals, tc.expectedIP)
+		adrfam := spdkclient.DetectAddressFamily(ip)
+		c.Assert(adrfam, Equals, tc.expectedAdrfam,
+			Commentf("Wrong adrfam for %s", tc.address))
+	}
 }

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/initiator/nvmecli.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/initiator/nvmecli.go
@@ -10,6 +10,8 @@ import (
 	commonns "github.com/longhorn/go-common-libs/ns"
 
 	"github.com/longhorn/go-spdk-helper/pkg/types"
+
+	spdkutil "github.com/longhorn/go-spdk-helper/pkg/util"
 )
 
 const (
@@ -234,9 +236,13 @@ func getHostID(executor *commonns.Executor) (string, error) {
 }
 
 func discovery(hostID, hostNQN, ip, port string, executor *commonns.Executor) ([]DiscoveryPageEntry, error) {
+	ip = spdkutil.NormalizeNvmeAddr(ip)
+
 	opts := []string{
 		"discover",
 		"-t", DefaultTransportType,
+		// nvme-cli -a accepts bare IPv6 (no brackets). net.SplitHostPort callers
+		// upstream strip brackets; util.NormalizeNvmeAddr is a safety net.
 		"-a", ip,
 		"-s", port,
 		"-o", "json",
@@ -303,6 +309,8 @@ func discovery(hostID, hostNQN, ip, port string, executor *commonns.Executor) ([
 }
 
 func connect(hostID, hostNQN, nqn, transpotType, ip, port string, executor *commonns.Executor) (string, error) {
+	ip = spdkutil.NormalizeNvmeAddr(ip)
+
 	var err error
 
 	opts := []string{
@@ -322,6 +330,8 @@ func connect(hostID, hostNQN, nqn, transpotType, ip, port string, executor *comm
 		opts = append(opts, "-q", hostNQN)
 	}
 	if ip != "" {
+		// nvme-cli -a accepts bare IPv6 (no brackets). net.SplitHostPort callers
+		// upstream strip brackets; util.NormalizeNvmeAddr is a safety net.
 		opts = append(opts, "-a", ip)
 	}
 	if port != "" {
@@ -402,8 +412,9 @@ func extractJSONString(str string) (string, error) {
 	return "", fmt.Errorf("invalid JSON string")
 }
 
-// GetIPAndPortFromControllerAddress returns the IP and port from the controller address
+// GetIPAndPortFromControllerAddress returns the IP and port from the controller address.
 // Input can be either "traddr=10.42.2.18 trsvcid=20006" or "traddr=10.42.2.18,trsvcid=20006"
+// for IPv4, or "traddr=fd00::1 trsvcid=20006" for IPv6 (traddr may contain colons).
 func GetIPAndPortFromControllerAddress(address string) (string, string) {
 	var traddr, trsvcid string
 
@@ -412,7 +423,7 @@ func GetIPAndPortFromControllerAddress(address string) (string, string) {
 	})
 
 	for _, part := range parts {
-		keyVal := strings.Split(part, "=")
+		keyVal := strings.SplitN(part, "=", 2)
 		if len(keyVal) == 2 {
 			key := strings.TrimSpace(keyVal[0])
 			value := strings.TrimSpace(keyVal[1])

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/client/advanced.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/client/advanced.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"net"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -8,6 +9,7 @@ import (
 	"github.com/longhorn/go-spdk-helper/pkg/jsonrpc"
 
 	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
+	spdkutil "github.com/longhorn/go-spdk-helper/pkg/util"
 )
 
 // AddDevice adds a device with the given device path, name, and cluster size.
@@ -55,8 +57,30 @@ func (c *Client) DeleteDevice(bdevAioName, lvsName string) (err error) {
 	return nil
 }
 
+// DetectAddressFamily returns the NVMe address family for the given IP.
+// Exported so downstream repos (longhorn-spdk-engine) can reuse it.
+func DetectAddressFamily(ip string) spdktypes.NvmeAddressFamily {
+	if ip == "" {
+		return spdktypes.NvmeAddressFamilyIPv4
+	}
+
+	normalized := spdkutil.NormalizeNvmeAddr(ip)
+	parsedIP := net.ParseIP(normalized)
+	if parsedIP == nil {
+		logrus.Warnf("Failed to parse IP %q, defaulting to IPv4", ip)
+		return spdktypes.NvmeAddressFamilyIPv4
+	}
+
+	if parsedIP.To4() == nil {
+		return spdktypes.NvmeAddressFamilyIPv6
+	}
+	return spdktypes.NvmeAddressFamilyIPv4
+}
+
 // StartExposeBdev exposes the bdev with the given nqn, bdevName, nguid, ip, and port.
 func (c *Client) StartExposeBdev(nqn, bdevName, nguid, ip, port string) error {
+	ip = spdkutil.NormalizeNvmeAddr(ip)
+
 	logrus.Infof("Exposing bdev with nqn %v, bdevName %v, nguid %v, ip %v, port %v", nqn, bdevName, nguid, ip, port)
 
 	nvmfTransportList, err := c.NvmfGetTransports("", "")
@@ -80,8 +104,10 @@ func (c *Client) StartExposeBdev(nqn, bdevName, nguid, ip, port string) error {
 		return err
 	}
 
-	logrus.Infof("Adding listener with transport address %v, transport service id %v, transport type %v, address family %v to subsystem with nqn %v", ip, port, spdktypes.NvmeTransportTypeTCP, spdktypes.NvmeAddressFamilyIPv4, nqn)
-	if _, err := c.NvmfSubsystemAddListener(nqn, ip, port, spdktypes.NvmeTransportTypeTCP, spdktypes.NvmeAddressFamilyIPv4); err != nil {
+	adrfam := DetectAddressFamily(ip)
+
+	logrus.Infof("Adding listener with transport address %v, transport service id %v, transport type %v, address family %v to subsystem with nqn %v", ip, port, spdktypes.NvmeTransportTypeTCP, adrfam, nqn)
+	if _, err := c.NvmfSubsystemAddListener(nqn, ip, port, spdktypes.NvmeTransportTypeTCP, adrfam); err != nil {
 		return err
 	}
 
@@ -95,6 +121,8 @@ func (c *Client) StartExposeBdev(nqn, bdevName, nguid, ip, port string) error {
 // a unique controller-ID range per engine to avoid "Duplicate cntlid" errors
 // when multiple targets share one subsystem NQN. Pass 0 for defaults.
 func (c *Client) StartExposeBdevWithANAState(nqn, bdevName, nguid, nsUUID, ip, port string, anaState spdktypes.NvmfSubsystemListenerAnaState, minCntlid, maxCntlid uint16) error {
+	ip = spdkutil.NormalizeNvmeAddr(ip)
+
 	logrus.Infof("Exposing bdev with nqn %v, bdevName %v, nguid %v, nsUUID %v, ip %v, port %v, anaState %v, minCntlid %v, maxCntlid %v",
 		nqn, bdevName, nguid, nsUUID, ip, port, anaState, minCntlid, maxCntlid)
 
@@ -119,14 +147,16 @@ func (c *Client) StartExposeBdevWithANAState(nqn, bdevName, nguid, nsUUID, ip, p
 		return err
 	}
 
-	logrus.Infof("Adding listener with transport address %v, transport service id %v, transport type %v, address family %v to subsystem with nqn %v", ip, port, spdktypes.NvmeTransportTypeTCP, spdktypes.NvmeAddressFamilyIPv4, nqn)
-	if _, err := c.NvmfSubsystemAddListener(nqn, ip, port, spdktypes.NvmeTransportTypeTCP, spdktypes.NvmeAddressFamilyIPv4); err != nil {
+	adrfam := DetectAddressFamily(ip)
+
+	logrus.Infof("Adding listener with transport address %v, transport service id %v, transport type %v, address family %v to subsystem with nqn %v", ip, port, spdktypes.NvmeTransportTypeTCP, adrfam, nqn)
+	if _, err := c.NvmfSubsystemAddListener(nqn, ip, port, spdktypes.NvmeTransportTypeTCP, adrfam); err != nil {
 		return err
 	}
 
 	logrus.Infof("Setting listener ANA state to %v for subsystem with nqn %v", anaState, nqn)
 	if _, err := c.NvmfSubsystemListenerSetANAState(nqn, ip, port, spdktypes.NvmeTransportTypeTCP,
-		spdktypes.NvmeAddressFamilyIPv4, anaState, spdktypes.DefaultNvmfANAGroupID); err != nil {
+		adrfam, anaState, spdktypes.DefaultNvmfANAGroupID); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/util/nvme.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/util/nvme.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -28,4 +29,14 @@ func GetNvmeNamespaceNameFromControllerName(controllerName string, nsID int) str
 func GetNvmeControllerNameFromNamespaceName(nsName string) string {
 	reg := regexp.MustCompile(`([^"]*)n\d+$`)
 	return reg.ReplaceAllString(nsName, "${1}")
+}
+
+// NormalizeNvmeAddr strips surrounding brackets from an IPv6 address if present.
+// Both nvme-cli (-a flag) and SPDK expect bare IPv6 (e.g., "fd00::1" not "[fd00::1]").
+func NormalizeNvmeAddr(ip string) string {
+	ip = strings.TrimSpace(ip)
+	if strings.HasPrefix(ip, "[") && strings.HasSuffix(ip, "]") {
+		ip = ip[1 : len(ip)-1]
+	}
+	return ip
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -126,7 +126,7 @@ github.com/longhorn/go-common-libs/sync
 github.com/longhorn/go-common-libs/sys
 github.com/longhorn/go-common-libs/types
 github.com/longhorn/go-common-libs/utils
-# github.com/longhorn/go-spdk-helper v0.5.1-0.20260416023608-49b12f8b468b
+# github.com/longhorn/go-spdk-helper v0.6.1-0.20260422091955-74dd5ebcf118
 ## explicit; go 1.25.3
 github.com/longhorn/go-spdk-helper/pkg/initiator
 github.com/longhorn/go-spdk-helper/pkg/jsonrpc


### PR DESCRIPTION
Replace hardcoded IPv4 address family with dynamic detection using net.ParseIP across engine, replica, and util modules.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10928

#### What this PR does / why we need it:

To make v2 data engine supports IPv6. This change dependent to longhorn/go-spdk-helper#276

#### Special notes for your reviewer:

#### Additional documentation or context
