### PR TITLE
fix(engine): defer ValidateAndUpdate error handling correctly

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -2721,7 +2721,9 @@ func (e *Engine) ValidateAndUpdate(spdkClient *spdkclient.Client) (err error) {
 		return err
 	}
 
-	defer e.applyValidateAndUpdateErrorNoLock(err, &updateRequired)
+	defer func() {
+		e.applyValidateAndUpdateErrorNoLock(err, &updateRequired)
+	}()
 
 	bdevRaid, err := e.getRaidBdevNoLock(bdevMap)
 	if err != nil {


### PR DESCRIPTION


#### Which issue(s) this PR fixes:

Longhorn/longhorn#7124
Longhorn/longhorn#10469

#### What this PR does / why we need it:

Wrap applyValidateAndUpdateErrorNoLock in an anonymous deferred closure so it observes the final named return error from ValidateAndUpdate.

Without the closure, the deferred call evaluates `err` at the defer site, before later operations can update it, which can skip the expected error handling and updateRequired propagation during validation failures.


#### Special notes for your reviewer:

#### Additional documentation or context
