### PR TITLE
fix(ci): workaround for broken systemd-presets-branding-SLE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,10 @@ RUN for i in {1..10}; do \
 
 RUN zypper -n ref && \
     zypper update -y
-RUN zypper -n install cmake curl wget gcc13 unzip tar xsltproc docbook-xsl-stylesheets python3 python3-pip fuse3-devel \
+
+# REMOVE ME: CI workaround for systemd-presets-branding-SLE-15.1-160099.8.1
+RUN zypper -n install systemd-presets-branding-SLE_transactional && \
+    zypper -n install --no-recommends cmake curl wget gcc13 unzip tar xsltproc docbook-xsl-stylesheets python3 python3-pip fuse3-devel \
               e2fsprogs xfsprogs util-linux-systemd libcmocka-devel device-mapper procps jq git && \
     rm -rf /var/cache/zypp/*
 


### PR DESCRIPTION
REVERT THIS: systemd-presets-branding-SLE currently points to systemd-presets-branding-SLE-15.1-160099.8.1, which is a broken release contains a truncated installation script. Revert this workaround once the upstream release is fixed.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#12971

#### What this PR does / why we need it:

This is a dependency workaround. We will revert this once the upstream systemd-presets-branding-SLE is fixed. 

#### Special notes for your reviewer:

#### Additional documentation or context
