### PR TITLE
fix(ci): revert workaround for broken systemd-presets-branding-SLE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,7 @@ RUN for i in {1..10}; do \
 
 RUN zypper -n ref && \
     zypper update -y
-
-# REMOVE ME: CI workaround for systemd-presets-branding-SLE-15.1-160099.8.1
-RUN zypper -n install systemd-presets-branding-SLE_transactional && \
-    zypper -n install --no-recommends cmake curl wget gcc13 unzip tar xsltproc docbook-xsl-stylesheets python3 python3-pip fuse3-devel \
+RUN zypper -n install cmake curl wget gcc13 unzip tar xsltproc docbook-xsl-stylesheets python3 python3-pip fuse3-devel \
               e2fsprogs xfsprogs util-linux-systemd libcmocka-devel device-mapper procps jq git && \
     rm -rf /var/cache/zypp/*
 


### PR DESCRIPTION


This reverts commit 7132206fba309809008676ae9eb1b95483cdfd5d.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#12975

#### What this PR does / why we need it:

Revert the workaround for upstream package `systemd-presets-branding-SLE` in CI pipe.

#### Special notes for your reviewer:

**Merge this PR only when it passes the build gate.**

#### Additional documentation or context
