### PR TITLE
fix(spdk): wait for NVMe detach to fully drain before cleanup

### DIFF
--- a/pkg/spdk/util.go
+++ b/pkg/spdk/util.go
@@ -192,7 +192,7 @@ func disconnectNVMfBdev(spdkClient *spdkclient.Client, bdevName string, maxRetri
 
 	controllerName := helperutil.GetNvmeControllerNameFromNamespaceName(bdevName)
 
-	return retry.Do(
+	if err := retry.Do(
 		func() error {
 			_, err := spdkClient.BdevNvmeDetachController(controllerName)
 			if err != nil {
@@ -211,6 +211,43 @@ func disconnectNVMfBdev(spdkClient *spdkclient.Client, bdevName string, maxRetri
 			logrus.WithError(err).Warnf(
 				"Retrying NVMe bdev detach: controller=%s attempt=%d/%d next_wait=%s",
 				controllerName, n+1, maxRetries, retryInterval,
+			)
+		}),
+	); err != nil {
+		return err
+	}
+
+	// BdevNvmeDetachController returning success only means SPDK accepted the detach
+	// request. The namespace bdev may still exist briefly while outstanding I/O drains.
+	// Wait until the namespace disappears before the caller tears down the peer
+	// exposure or deletes the parent lvol; otherwise SPDK can assert in
+	// bdev_channel_destroy_resource() with io_submitted still queued.
+	return waitForNVMfBdevDetached(spdkClient, bdevName, controllerName, maxRetries, retryInterval)
+}
+
+func waitForNVMfBdevDetached(spdkClient *spdkclient.Client, bdevName, controllerName string, maxRetries int, retryInterval time.Duration) error {
+	return retry.Do(
+		func() error {
+			bdevs, err := spdkClient.BdevGetBdevs(bdevName, 0)
+			if err != nil {
+				if jsonrpc.IsJSONRPCRespErrorNoSuchDevice(err) {
+					return nil
+				}
+				return err
+			}
+			if len(bdevs) == 0 {
+				return nil
+			}
+			return fmt.Errorf("NVMe bdev %s for controller %s is still present after detach", bdevName, controllerName)
+		},
+		retry.Attempts(uint(maxRetries)),
+		retry.Delay(retryInterval),
+		retry.DelayType(retry.FixedDelay),
+		retry.LastErrorOnly(true),
+		retry.OnRetry(func(n uint, err error) {
+			logrus.WithError(err).Warnf(
+				"Waiting for NVMe bdev removal: bdev=%s controller=%s attempt=%d/%d next_wait=%s",
+				bdevName, controllerName, n+1, maxRetries, retryInterval,
 			)
 		}),
 	)

--- a/pkg/spdk_test.go
+++ b/pkg/spdk_test.go
@@ -2103,9 +2103,9 @@ func (s *TestSuite) TestSPDKMultipleThread(c *C) {
 			// Before testing online rebuilding
 			// Crash replica2 and remove it from the engine
 			delete(replicaAddressMap, replicaName2)
-			err = spdkCli.ReplicaDelete(replicaName2, true)
-			c.Assert(err, IsNil)
 			err = spdkCli.EngineReplicaDelete(engineName, replicaName2, net.JoinHostPort(ip, strconv.Itoa(int(replica2.PortStart))))
+			c.Assert(err, IsNil)
+			err = spdkCli.ReplicaDelete(replicaName2, true)
 			c.Assert(err, IsNil)
 			engine, err = spdkCli.EngineGet(engineName)
 			c.Assert(err, IsNil)
@@ -2903,9 +2903,9 @@ func (s *TestSuite) spdkMultipleThreadSnapshotOpsAndRebuilding(c *C, withBacking
 
 			// Crash replica1
 			delete(replicaAddressMap, replicaName1)
-			err = spdkCli.ReplicaDelete(replicaName1, true)
-			c.Assert(err, IsNil)
 			err = spdkCli.EngineReplicaDelete(engineName, replicaName1, net.JoinHostPort(ip, strconv.Itoa(int(replica1.PortStart))))
+			c.Assert(err, IsNil)
+			err = spdkCli.ReplicaDelete(replicaName1, true)
 			c.Assert(err, IsNil)
 			engine, err = spdkCli.EngineGet(engineName)
 			c.Assert(err, IsNil)
@@ -3001,9 +3001,9 @@ func (s *TestSuite) spdkMultipleThreadSnapshotOpsAndRebuilding(c *C, withBacking
 
 			// Crash replica2
 			delete(replicaAddressMap, replicaName2)
-			err = spdkCli.ReplicaDelete(replicaName2, true)
-			c.Assert(err, IsNil)
 			err = spdkCli.EngineReplicaDelete(engineName, replicaName2, net.JoinHostPort(ip, strconv.Itoa(int(replica2.PortStart))))
+			c.Assert(err, IsNil)
+			err = spdkCli.ReplicaDelete(replicaName2, true)
 			c.Assert(err, IsNil)
 			engine, err = spdkCli.EngineGet(engineName)
 			c.Assert(err, IsNil)


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13076

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
