### PR TITLE
fix: enforce snapshot-max-count/size for v2 volumes

### DIFF
--- a/pkg/client/client_engine.go
+++ b/pkg/client/client_engine.go
@@ -469,3 +469,29 @@ func (c *SPDKClient) EngineRestoreStatus(engineName string) (*spdkrpc.RestoreSta
 		EngineName: engineName,
 	})
 }
+
+// VolumeSnapshotMaxCountSet sets the maximum number of snapshots allowed for an engine.
+func (c *SPDKClient) VolumeSnapshotMaxCountSet(engineName string, count int) error {
+	client := c.getSPDKServiceClient()
+	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
+	defer cancel()
+
+	_, err := client.EngineVolumeSnapshotMaxCountSet(ctx, &spdkrpc.EngineVolumeSnapshotMaxCountSetRequest{
+		Name:  engineName,
+		Count: int32(count),
+	})
+	return errors.Wrapf(err, "failed to set snapshot max count for engine %v", engineName)
+}
+
+// VolumeSnapshotMaxSizeSet sets the maximum total size of snapshots allowed for an engine.
+func (c *SPDKClient) VolumeSnapshotMaxSizeSet(engineName string, size int64) error {
+	client := c.getSPDKServiceClient()
+	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
+	defer cancel()
+
+	_, err := client.EngineVolumeSnapshotMaxSizeSet(ctx, &spdkrpc.EngineVolumeSnapshotMaxSizeSetRequest{
+		Name: engineName,
+		Size: size,
+	})
+	return errors.Wrapf(err, "failed to set snapshot max size for engine %v", engineName)
+}

--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -145,6 +145,9 @@ type Engine struct {
 	lastExpansionFailedAt string
 	lastExpansionError    string
 
+	SnapshotMaxCount int
+	SnapshotMaxSize  int64
+
 	// UpdateCh should not be protected by the engine lock
 	UpdateCh chan interface{}
 
@@ -1485,8 +1488,30 @@ const (
 	SnapshotOperationHash   = SnapshotOperationType("snapshot-hash")
 )
 
+func (e *Engine) VolumeSnapshotMaxCountSet(count int) {
+	e.Lock()
+	defer e.Unlock()
+	e.SnapshotMaxCount = count
+	e.log.Infof("Set engine snapshot max count to %d", count)
+}
+
+func (e *Engine) VolumeSnapshotMaxSizeSet(size int64) {
+	e.Lock()
+	defer e.Unlock()
+	e.SnapshotMaxSize = size
+	e.log.Infof("Set engine snapshot max size to %d", size)
+}
+
 func (e *Engine) SnapshotCreate(spdkClient *spdkclient.Client, inputSnapshotName string) (snapshotName string, err error) {
 	e.log.Infof("Creating snapshot %s", inputSnapshotName)
+
+	e.RLock()
+	maxCount := e.SnapshotMaxCount
+	e.RUnlock()
+	if maxCount > 0 && len(e.SnapshotMap) >= maxCount {
+		return "", fmt.Errorf("snapshot count %d has reached the maximum snapshot count %d",
+			len(e.SnapshotMap), maxCount)
+	}
 
 	opts := &api.SnapshotOptions{
 		UserCreated: true,

--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -80,6 +80,9 @@ type Replica struct {
 	IsExposed               bool
 	SnapshotChecksumEnabled bool
 
+	SnapshotMaxCount int
+	SnapshotMaxSize  int64
+
 	// SnapshotLvolHashStatusMap map[<snapshot lvol name>]LvolHashStatus.
 	SnapshotLvolHashStatusMap sync.Map
 
@@ -1449,6 +1452,20 @@ func getSnapshotXattrsFromOptions(opts *api.SnapshotOptions) []spdkclient.Xattr 
 	}
 }
 
+func (r *Replica) VolumeSnapshotMaxCountSet(count int) {
+	r.Lock()
+	defer r.Unlock()
+	r.SnapshotMaxCount = count
+	r.log.Infof("Set replica snapshot max count to %d", count)
+}
+
+func (r *Replica) VolumeSnapshotMaxSizeSet(size int64) {
+	r.Lock()
+	defer r.Unlock()
+	r.SnapshotMaxSize = size
+	r.log.Infof("Set replica snapshot max size to %d", size)
+}
+
 func (r *Replica) SnapshotCreate(spdkClient *spdkclient.Client, snapshotName string, opts *api.SnapshotOptions) (replica *spdkrpc.Replica, err error) {
 	updateRequired := false
 
@@ -1465,6 +1482,10 @@ func (r *Replica) SnapshotCreate(spdkClient *spdkclient.Client, snapshotName str
 
 	if r.State != types.InstanceStateStopped && r.State != types.InstanceStateRunning {
 		return nil, fmt.Errorf("invalid state %v for replica %s snapshot creation", r.State, r.Name)
+	}
+
+	if r.SnapshotMaxCount > 0 && len(r.SnapshotLvolMap) >= r.SnapshotMaxCount {
+		return nil, fmt.Errorf("snapshot count %d has reached the maximum snapshot count %d for replica %s", len(r.SnapshotLvolMap), r.SnapshotMaxCount, r.Name)
 	}
 
 	snapLvolName := GetReplicaSnapshotLvolName(r.Name, snapshotName)

--- a/pkg/spdk/server_engine.go
+++ b/pkg/spdk/server_engine.go
@@ -626,3 +626,37 @@ func (s *Server) EngineRestoreStatus(ctx context.Context, req *spdkrpc.RestoreSt
 	}
 	return resp, nil
 }
+
+func (s *Server) EngineVolumeSnapshotMaxCountSet(ctx context.Context, req *spdkrpc.EngineVolumeSnapshotMaxCountSetRequest) (*emptypb.Empty, error) {
+	if req.Name == "" {
+		return nil, grpcstatus.Error(grpccodes.InvalidArgument, "engine name is required")
+	}
+
+	s.RLock()
+	e := s.engineMap[req.Name]
+	s.RUnlock()
+
+	if e == nil {
+		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find engine %v for snapshot max count set", req.Name)
+	}
+
+	e.VolumeSnapshotMaxCountSet(int(req.Count))
+	return &emptypb.Empty{}, nil
+}
+
+func (s *Server) EngineVolumeSnapshotMaxSizeSet(ctx context.Context, req *spdkrpc.EngineVolumeSnapshotMaxSizeSetRequest) (*emptypb.Empty, error) {
+	if req.Name == "" {
+		return nil, grpcstatus.Error(grpccodes.InvalidArgument, "engine name is required")
+	}
+
+	s.RLock()
+	e := s.engineMap[req.Name]
+	s.RUnlock()
+
+	if e == nil {
+		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find engine %v for snapshot max size set", req.Name)
+	}
+
+	e.VolumeSnapshotMaxSizeSet(req.Size)
+	return &emptypb.Empty{}, nil
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
The v2 (SPDK) engine had no enforcement logic for SnapshotMaxCount and SnapshotMaxSize. Add:
- SnapshotMaxCount/SnapshotMaxSize fields to Engine and Replica structs
- Enforcement check in SnapshotCreate
- VolumeSnapshotMaxCountSet/VolumeSnapshotMaxSizeSet gRPC handlers
- Client methods for the new RPCs

Fixes longhorn#12921

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
