### PR TITLE
fix: prevent resource leaks in backup, restore, and backing image cleanup paths

### DIFF
--- a/pkg/spdk/backing_image.go
+++ b/pkg/spdk/backing_image.go
@@ -21,7 +21,6 @@ import (
 	"github.com/longhorn/types/pkg/generated/spdkrpc"
 
 	commonbitmap "github.com/longhorn/go-common-libs/bitmap"
-	commonnet "github.com/longhorn/go-common-libs/net"
 	commontypes "github.com/longhorn/go-common-libs/types"
 	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
 	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
@@ -311,7 +310,7 @@ func (bi *BackingImage) BackingImageExpose(spdkClient *spdkclient.Client, superi
 	}
 
 	// Expose the bdev using nvmf
-	podIP, err := commonnet.GetIPForPod()
+	podIP, err := backingImageGetIPForPod()
 	if err != nil {
 		return "", err
 	}
@@ -423,7 +422,7 @@ func (bi *BackingImage) prepareBackingImageSnapshot(spdkClient *spdkclient.Clien
 		if bi.IsExposed {
 			bi.log.Info("Unexposing lvol bdev")
 			backingImageTempHeadName := GetBackingImageTempHeadLvolName(bi.Name, bi.LvsUUID)
-			if err = spdkClient.StopExposeBdev(helpertypes.GetNQN(backingImageTempHeadName)); err != nil {
+			if err = backingImageStopExposeBdev(spdkClient, helpertypes.GetNQN(backingImageTempHeadName)); err != nil {
 				bi.log.WithError(err).Errorf("Failed to unexpose lvol bdev %v after failed to create backing image", backingImageTempHeadName)
 			}
 			bi.IsExposed = false
@@ -485,7 +484,7 @@ func (bi *BackingImage) prepareBackingImageSnapshot(spdkClient *spdkclient.Clien
 	}()
 
 	bi.Lock()
-	lvsName, err := GetLvsNameByUUID(spdkClient, bi.LvsUUID)
+	lvsName, err := backingImageGetLvsNameByUUID(spdkClient, bi.LvsUUID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get the lvs name for backing image %v with lvs uuid %v", bi.Name, bi.LvsUUID)
 	}
@@ -501,11 +500,11 @@ func (bi *BackingImage) prepareBackingImageSnapshot(spdkClient *spdkclient.Clien
 
 	// backingImageTempHeadName will be "bi-${biName}-disk-${lvsUUID}-temp-head"
 	backingImageTempHeadName := GetBackingImageTempHeadLvolName(bi.Name, bi.LvsUUID)
-	biTempHeadUUID, err = spdkClient.BdevLvolCreate("", bi.LvsUUID, backingImageTempHeadName, util.BytesToMiB(bi.Size), "", true)
+	biTempHeadUUID, err = backingImageBdevLvolCreate(spdkClient, "", bi.LvsUUID, backingImageTempHeadName, util.BytesToMiB(bi.Size), "", true)
 	if err != nil {
 		return err
 	}
-	bdevLvolList, err := spdkClient.BdevLvolGet(biTempHeadUUID, 0)
+	bdevLvolList, err := backingImageBdevLvolGet(spdkClient, biTempHeadUUID, 0)
 	if err != nil {
 		return err
 	}
@@ -514,7 +513,7 @@ func (bi *BackingImage) prepareBackingImageSnapshot(spdkClient *spdkclient.Clien
 	}
 	bi.log.Infof("Created a head lvol %v for the new backing image", backingImageTempHeadName)
 
-	podIP, err := commonnet.GetIPForPod()
+	podIP, err := backingImageGetIPForPod()
 	if err != nil {
 		return err
 	}
@@ -527,11 +526,11 @@ func (bi *BackingImage) prepareBackingImageSnapshot(spdkClient *spdkclient.Clien
 	bi.Unlock()
 	bi.log.Infof("Allocated port %v", port)
 
-	executor, err := helperutil.NewExecutor(commontypes.ProcDirectory)
+	executor, err := backingImageNewExecutor(commontypes.ProcDirectory)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create executor")
 	}
-	subsystemNQN, controllerName, err := exposeSnapshotLvolBdev(spdkClient, bi.LvsName, backingImageTempHeadName, podIP, port, executor)
+	subsystemNQN, controllerName, err := backingImageExposeSnapshotLvolBdev(spdkClient, bi.LvsName, backingImageTempHeadName, podIP, port, executor)
 	if err != nil {
 		bi.log.WithError(err).Errorf("Failed to expose head lvol")
 		return err
@@ -544,7 +543,7 @@ func (bi *BackingImage) prepareBackingImageSnapshot(spdkClient *spdkclient.Clien
 	nvmeTCPInfo := &initiator.NVMeTCPInfo{
 		SubsystemNQN: helpertypes.GetNQN(backingImageTempHeadName),
 	}
-	headInitiator, err := initiator.NewInitiator(backingImageTempHeadName, initiator.HostProc, nvmeTCPInfo, nil)
+	headInitiator, err := newNVMeTCPInitiator(backingImageTempHeadName, nvmeTCPInfo)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create NVMe initiator for head lvol %v", backingImageTempHeadName)
 	}
@@ -553,20 +552,22 @@ func (bi *BackingImage) prepareBackingImageSnapshot(spdkClient *spdkclient.Clien
 	}
 	bi.log.Infof("Created NVMe initiator for head lvol %v", backingImageTempHeadName)
 
-	headFh, err := os.OpenFile(headInitiator.Endpoint, os.O_RDWR, 0666)
 	defer func() {
-		// Stop the initiator
-		if errClose := headFh.Close(); errClose != nil {
-			bi.log.WithError(errClose).Error("Failed to close the backing image")
-		}
 		bi.log.Info("Stopping NVMe initiator")
 		if _, opErr := headInitiator.Stop(nil, true, true, false); opErr != nil {
 			bi.log.WithError(opErr).Error("Failed to stop the backing image head NVMe initiator")
 		}
 	}()
+
+	headFh, err := openFile(headInitiator.Endpoint(), os.O_RDWR, 0666)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open NVMe device %v for lvol bdev %v", headInitiator.Endpoint, backingImageTempHeadName)
+		return errors.Wrapf(err, "failed to open NVMe device %v for lvol bdev %v", headInitiator.Endpoint(), backingImageTempHeadName)
 	}
+	defer func() {
+		if errClose := headFh.Close(); errClose != nil {
+			bi.log.WithError(errClose).Error("Failed to close the backing image")
+		}
+	}()
 
 	// An SPDK backing image should only be created by downloading it from BIM if it's a first copy,
 	// or by syncing it from another SPDK server.
@@ -583,9 +584,9 @@ func (bi *BackingImage) prepareBackingImageSnapshot(spdkClient *spdkclient.Clien
 		}
 	}
 
-	currentChecksum, err := util.GetFileChecksum(headInitiator.Endpoint)
+	currentChecksum, err := util.GetFileChecksum(headInitiator.Endpoint())
 	if err != nil {
-		return errors.Wrapf(err, "failed to get the current checksum of the backing image %v target device %v", bi.Name, headInitiator.Endpoint)
+		return errors.Wrapf(err, "failed to get the current checksum of the backing image %v target device %v", bi.Name, headInitiator.Endpoint())
 	}
 	bi.log.Infof("Get the current checksum of the backing image %v: %v", bi.Name, currentChecksum)
 	bi.Lock()
@@ -680,7 +681,7 @@ func (bi *BackingImage) prepareFromSync(targetFh *os.File, fromAddress, srcLvsUU
 	if fromAddress == "" || srcLvsUUID == "" {
 		return errors.Wrapf(err, "missing required source backing image service address %v or source lvsUUID %v", fromAddress, srcLvsUUID)
 	}
-	srcBackingImageServiceCli, err := GetServiceClient(fromAddress)
+	srcBackingImageServiceCli, err := backingImageGetServiceClient(fromAddress)
 	if err != nil {
 		return errors.Wrapf(err, "failed to init the source backing image spdk service client")
 	}
@@ -705,7 +706,7 @@ func (bi *BackingImage) prepareFromSync(targetFh *os.File, fromAddress, srcLvsUU
 	if err != nil {
 		return errors.Wrapf(err, "failed to split host and port from address %v", exposedSnapshotLvolAddress)
 	}
-	_, _, err = discoverAndConnectNVMeTarget(srcIP, srcPort, maxRetries, retryInterval)
+	_, _, err = backingImageDiscoverAndConnectNVMeTarget(srcIP, srcPort, maxRetries, retryInterval)
 	if err != nil {
 		return errors.Wrapf(err, "failed to connect to NVMe target for source backing image %v in lvsUUID %v with address %v", bi.Name, srcLvsUUID, exposedSnapshotLvolAddress)
 	}
@@ -714,7 +715,7 @@ func (bi *BackingImage) prepareFromSync(targetFh *os.File, fromAddress, srcLvsUU
 	nvmeTCPInfo := &initiator.NVMeTCPInfo{
 		SubsystemNQN: helpertypes.GetNQN(externalSnapshotLvolName),
 	}
-	i, err := initiator.NewInitiator(externalSnapshotLvolName, initiator.HostProc, nvmeTCPInfo, nil)
+	i, err := newNVMeTCPInitiator(externalSnapshotLvolName, nvmeTCPInfo)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create NVMe initiator for source backing image %v in lvsUUID %v with address %v", bi.Name, srcLvsUUID, exposedSnapshotLvolAddress)
 	}
@@ -722,21 +723,23 @@ func (bi *BackingImage) prepareFromSync(targetFh *os.File, fromAddress, srcLvsUU
 		return errors.Wrapf(err, "failed to start NVMe initiator for source backing image %v in lvsUUID %v with address %v", bi.Name, srcLvsUUID, exposedSnapshotLvolAddress)
 	}
 
-	bi.log.Infof("Opening NVMe device %v", i.Endpoint)
-	srcFh, err := os.OpenFile(i.Endpoint, os.O_RDWR, 0666)
 	defer func() {
-		if errClose := srcFh.Close(); errClose != nil {
-			bi.log.WithError(errClose).Error("Failed to close the source backing image")
-		}
-		// Stop the source initiator
 		bi.log.Info("Stopping NVMe initiator")
 		if _, err := i.Stop(nil, true, true, false); err != nil {
 			bi.log.WithError(err).Warnf("failed to stop NVMe initiator")
 		}
 	}()
+
+	bi.log.Infof("Opening NVMe device %v", i.Endpoint())
+	srcFh, err := openFile(i.Endpoint(), os.O_RDWR, 0666)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open NVMe device %v for source backing image %v in lvsUUID %v with address %v", i.Endpoint, bi.Name, srcLvsUUID, exposedSnapshotLvolAddress)
+		return errors.Wrapf(err, "failed to open NVMe device %v for source backing image %v in lvsUUID %v with address %v", i.Endpoint(), bi.Name, srcLvsUUID, exposedSnapshotLvolAddress)
 	}
+	defer func() {
+		if errClose := srcFh.Close(); errClose != nil {
+			bi.log.WithError(errClose).Error("Failed to close the source backing image")
+		}
+	}()
 
 	ctx, cancel := context.WithCancel(bi.ctx)
 	defer cancel()

--- a/pkg/spdk/backup.go
+++ b/pkg/spdk/backup.go
@@ -224,6 +224,9 @@ func (b *Backup) OpenSnapshot(snapshotName, volumeName string) (err error) {
 		return errors.Wrapf(err, "failed to create NVMe initiator for snapshot lvol bdev %v", lvolName)
 	}
 	if _, err := i.StartNvmeTCPInitiator(b.IP, strconv.Itoa(int(b.Port)), false, true); err != nil {
+		if _, stopErr := i.Stop(nil, true, true, true); stopErr != nil {
+			b.log.WithError(stopErr).Warnf("Failed to stop partially-started NVMe initiator for snapshot lvol bdev %v", lvolName)
+		}
 		return errors.Wrapf(err, "failed to start NVMe initiator for snapshot lvol bdev %v", lvolName)
 	}
 	b.initiator = i

--- a/pkg/spdk/backup.go
+++ b/pkg/spdk/backup.go
@@ -177,26 +177,29 @@ func (b *Backup) OpenSnapshot(snapshotName, volumeName string) (err error) {
 		if b.devFh != nil {
 			if errClose := b.devFh.Close(); errClose != nil {
 				b.log.WithError(errClose).Warnf("Failed to close NVMe device %v during backup open cleanup", b.devFh.Name())
+			} else {
+				b.devFh = nil
 			}
-			b.devFh = nil
 		}
 
 		if b.initiator != nil {
 			if _, stopErr := b.initiator.Stop(nil, true, true, true); stopErr != nil {
 				b.log.WithError(stopErr).Warnf("Failed to stop NVMe initiator for snapshot lvol bdev %v during backup open cleanup", lvolName)
+			} else {
+				b.initiator = nil
 			}
-			b.initiator = nil
 		}
 
 		if exposed {
 			if stopErr := backupStopExposeBdev(b.spdkClient, helpertypes.GetNQN(lvolName)); stopErr != nil {
 				b.log.WithError(stopErr).Warnf("Failed to unexpose snapshot lvol bdev %v during backup open cleanup", lvolName)
+			} else {
+				b.subsystemNQN = ""
+				b.controllerName = ""
 			}
 		}
 
 		b.fragmap = nil
-		b.subsystemNQN = ""
-		b.controllerName = ""
 	}()
 
 	b.replica.Lock()
@@ -311,6 +314,8 @@ func (b *Backup) CloseSnapshot(snapshotName, volumeName string) error {
 			} else {
 				errs = append(errs, errors.Wrap(err, "failed to close NVMe device"))
 			}
+		} else {
+			b.devFh = nil
 		}
 	}
 
@@ -318,6 +323,8 @@ func (b *Backup) CloseSnapshot(snapshotName, volumeName string) error {
 		b.log.Info("Stopping NVMe initiator")
 		if _, err := b.initiator.Stop(nil, true, true, true); err != nil {
 			errs = append(errs, errors.Wrapf(err, "failed to stop NVMe initiator"))
+		} else {
+			b.initiator = nil
 		}
 	}
 
@@ -325,11 +332,16 @@ func (b *Backup) CloseSnapshot(snapshotName, volumeName string) error {
 		b.log.Info("Unexposing snapshot lvol bdev")
 		if err := backupStopExposeBdev(b.spdkClient, helpertypes.GetNQN(lvolName)); err != nil {
 			errs = append(errs, errors.Wrapf(err, "failed to unexpose snapshot lvol bdev %v", lvolName))
+		} else {
+			b.subsystemNQN = ""
+			b.controllerName = ""
 		}
 	}
 
-	b.releaseHeavyResourcesLocked()
-	b.markTerminalHandledLocked()
+	errs = append(errs, b.releaseHeavyResourcesLocked()...)
+	if len(errs) == 0 && !b.hasActiveSnapshotResourcesLocked() {
+		b.markTerminalHandledLocked()
+	}
 
 	if len(errs) > 0 {
 		return errors.Errorf("CloseSnapshot encountered %d error(s): %v", len(errs), errs)
@@ -355,20 +367,34 @@ func (b *Backup) markTerminalHandledLocked() {
 	}
 }
 
-func (b *Backup) releaseHeavyResourcesLocked() {
+func (b *Backup) releaseHeavyResourcesLocked() (errs []error) {
+	// Only release the port when all resources that depend on it have been
+	// cleaned up. If the NVMe-oF target is still exposed (subsystemNQN != "")
+	// or the kernel-side initiator/device is still connected, releasing the
+	// port risks reuse while the old target is still active.
 	if b.portAllocator != nil && b.Port != 0 {
-		if err := b.portAllocator.ReleaseRange(b.Port, b.Port); err != nil {
-			b.log.WithError(err).Warnf("Failed to release port %v", b.Port)
+		if b.subsystemNQN != "" || b.initiator != nil || b.devFh != nil {
+			b.log.Warnf("Skipping port %v release: resources still active (subsystemNQN=%q, initiator=%v, devFh=%v)",
+				b.Port, b.subsystemNQN, b.initiator != nil, b.devFh != nil)
+		} else {
+			if err := b.portAllocator.ReleaseRange(b.Port, b.Port); err != nil {
+				b.log.WithError(err).Warnf("Failed to release port %v", b.Port)
+				errs = append(errs, errors.Wrapf(err, "failed to release backup port %v", b.Port))
+			} else {
+				b.portAllocator = nil
+			}
 		}
-		b.portAllocator = nil
 	}
 	b.fragmap = nil
-	b.initiator = nil
-	b.devFh = nil
 	b.executor = nil
-	b.subsystemNQN = ""
-	b.controllerName = ""
-	b.replica = nil
+	if !b.hasActiveSnapshotResourcesLocked() {
+		b.replica = nil
+	}
+	return errs
+}
+
+func (b *Backup) hasActiveSnapshotResourcesLocked() bool {
+	return (b.portAllocator != nil && b.Port != 0) || b.subsystemNQN != "" || b.initiator != nil || b.devFh != nil
 }
 
 // UpdateBackupStatus updates the backup status. The state is first-respected, but if

--- a/pkg/spdk/backup.go
+++ b/pkg/spdk/backup.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	"github.com/cockroachdb/errors"
@@ -36,16 +37,18 @@ type Fragmap struct {
 type Backup struct {
 	sync.Mutex
 
-	spdkClient *spdkclient.Client
+	spdkClient    *spdkclient.Client
+	portAllocator *commonbitmap.Bitmap
 
-	Name          string
-	VolumeName    string
-	SnapshotName  string
-	replica       *Replica
-	fragmap       *Fragmap
-	IP            string
-	Port          int32
-	IsIncremental bool
+	Name           string
+	VolumeName     string
+	SnapshotName   string
+	replica        *Replica
+	replicaAddress string
+	fragmap        *Fragmap
+	IP             string
+	Port           int32
+	IsIncremental  bool
 
 	BackupURL string
 	State     btypes.ProgressState
@@ -54,9 +57,20 @@ type Backup struct {
 
 	subsystemNQN   string
 	controllerName string
-	initiator      *initiator.Initiator
+	initiator      nvmeInitiator
 	devFh          *os.File
 	executor       *commonns.Executor
+
+	// onTerminal is invoked (in a new goroutine) exactly once when the
+	// backup first reaches a terminal state (Complete or Error) AND
+	// CloseSnapshot has finished releasing all heavy resources.
+	// The server uses this hook to trigger pruning of retained backups.
+	onTerminal func()
+	// terminalSeen guards onTerminal so it fires at most once.
+	terminalSeen bool
+	// terminalAt records when the backup entered a terminal state,
+	// used by the pruning logic to evict the oldest entries first.
+	terminalAt time.Time
 
 	log logrus.FieldLogger
 }
@@ -64,7 +78,7 @@ type Backup struct {
 var _ backupstore.DeltaBlockBackupOperations = (*Backup)(nil)
 
 // NewBackup creates a new backup instance
-func NewBackup(spdkClient *spdkclient.Client, backupName, volumeName, snapshotName string, replica *Replica, superiorPortAllocator *commonbitmap.Bitmap) (*Backup, error) {
+func NewBackup(spdkClient *spdkclient.Client, backupName, volumeName, snapshotName string, replica *Replica, superiorPortAllocator *commonbitmap.Bitmap, onTerminal func()) (*Backup, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"backupName":   backupName,
 		"volumeName":   volumeName,
@@ -72,6 +86,11 @@ func NewBackup(spdkClient *spdkclient.Client, backupName, volumeName, snapshotNa
 	})
 
 	log.Info("Initializing backup")
+
+	replicaAddress := ""
+	if replica != nil {
+		replicaAddress = replica.GetAddress()
+	}
 
 	podIP, err := commonnet.GetIPForPod()
 	if err != nil {
@@ -85,20 +104,26 @@ func NewBackup(spdkClient *spdkclient.Client, backupName, volumeName, snapshotNa
 
 	executor, err := helperutil.NewExecutor(commontypes.ProcDirectory)
 	if err != nil {
+		if releaseErr := superiorPortAllocator.ReleaseRange(port, port); releaseErr != nil {
+			log.WithError(releaseErr).Warnf("Failed to release port %v after executor creation failure", port)
+		}
 		return nil, errors.Wrapf(err, "failed to create executor")
 	}
 
 	return &Backup{
-		spdkClient:   spdkClient,
-		Name:         backupName,
-		VolumeName:   volumeName,
-		SnapshotName: snapshotName,
-		replica:      replica,
-		IP:           podIP,
-		Port:         port,
-		State:        btypes.ProgressStateInProgress,
-		log:          log,
-		executor:     executor,
+		spdkClient:     spdkClient,
+		portAllocator:  superiorPortAllocator,
+		Name:           backupName,
+		VolumeName:     volumeName,
+		SnapshotName:   snapshotName,
+		replica:        replica,
+		replicaAddress: replicaAddress,
+		IP:             podIP,
+		Port:           port,
+		State:          btypes.ProgressStateInProgress,
+		log:            log,
+		executor:       executor,
+		onTerminal:     onTerminal,
 	}, nil
 }
 
@@ -131,28 +156,59 @@ func (b *Backup) HasSnapshot(snapshotName, volumeName string) bool {
 }
 
 // OpenSnapshot opens the snapshot lvol for backup
-func (b *Backup) OpenSnapshot(snapshotName, volumeName string) error {
+func (b *Backup) OpenSnapshot(snapshotName, volumeName string) (err error) {
 	b.Lock()
 	defer b.Unlock()
 
 	b.log.Info("Preparing snapshot lvol bdev for backup")
-	frgmap, err := b.newFragmap()
+	frgmap, err := backupNewFragmap(b)
 	if err != nil {
 		return err
 	}
 	b.fragmap = frgmap
 
 	lvolName := GetReplicaSnapshotLvolName(b.replica.Name, snapshotName)
+	exposed := false
+	defer func() {
+		if err == nil {
+			return
+		}
+
+		if b.devFh != nil {
+			if errClose := b.devFh.Close(); errClose != nil {
+				b.log.WithError(errClose).Warnf("Failed to close NVMe device %v during backup open cleanup", b.devFh.Name())
+			}
+			b.devFh = nil
+		}
+
+		if b.initiator != nil {
+			if _, stopErr := b.initiator.Stop(nil, true, true, true); stopErr != nil {
+				b.log.WithError(stopErr).Warnf("Failed to stop NVMe initiator for snapshot lvol bdev %v during backup open cleanup", lvolName)
+			}
+			b.initiator = nil
+		}
+
+		if exposed {
+			if stopErr := backupStopExposeBdev(b.spdkClient, helpertypes.GetNQN(lvolName)); stopErr != nil {
+				b.log.WithError(stopErr).Warnf("Failed to unexpose snapshot lvol bdev %v during backup open cleanup", lvolName)
+			}
+		}
+
+		b.fragmap = nil
+		b.subsystemNQN = ""
+		b.controllerName = ""
+	}()
 
 	b.replica.Lock()
 	defer b.replica.Unlock()
 
 	b.log.Infof("Exposing snapshot lvol bdev %v", lvolName)
-	subsystemNQN, controllerName, err := exposeSnapshotLvolBdev(b.spdkClient, b.replica.LvsName, lvolName, b.IP, b.Port, b.executor)
+	subsystemNQN, controllerName, err := backupExposeSnapshotLvolBdev(b.spdkClient, b.replica.LvsName, lvolName, b.IP, b.Port, b.executor)
 	if err != nil {
 		b.log.WithError(err).Errorf("Failed to expose snapshot lvol bdev %v", lvolName)
 		return errors.Wrapf(err, "failed to expose snapshot lvol bdev %v", lvolName)
 	}
+	exposed = true
 	b.subsystemNQN = subsystemNQN
 	b.controllerName = controllerName
 
@@ -160,7 +216,7 @@ func (b *Backup) OpenSnapshot(snapshotName, volumeName string) error {
 	nvmeTCPInfo := &initiator.NVMeTCPInfo{
 		SubsystemNQN: helpertypes.GetNQN(lvolName),
 	}
-	i, err := initiator.NewInitiator(lvolName, initiator.HostProc, nvmeTCPInfo, nil)
+	i, err := newNVMeTCPInitiator(lvolName, nvmeTCPInfo)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create NVMe initiator for snapshot lvol bdev %v", lvolName)
 	}
@@ -169,10 +225,10 @@ func (b *Backup) OpenSnapshot(snapshotName, volumeName string) error {
 	}
 	b.initiator = i
 
-	b.log.Infof("Opening NVMe device %v", b.initiator.Endpoint)
-	devFh, err := os.OpenFile(b.initiator.Endpoint, os.O_RDONLY, 0666)
+	b.log.Infof("Opening NVMe device %v", b.initiator.Endpoint())
+	devFh, err := openFile(b.initiator.Endpoint(), os.O_RDONLY, 0666)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open NVMe device %v for snapshot lvol bdev %v", b.initiator.Endpoint, lvolName)
+		return errors.Wrapf(err, "failed to open NVMe device %v for snapshot lvol bdev %v", b.initiator.Endpoint(), lvolName)
 	}
 	b.devFh = devFh
 
@@ -235,24 +291,84 @@ func (b *Backup) CloseSnapshot(snapshotName, volumeName string) error {
 	b.Lock()
 	defer b.Unlock()
 
-	b.log.Infof("Closing NVMe device %v", b.initiator.Endpoint)
-	if err := b.devFh.Close(); err != nil {
-		return errors.Wrapf(err, "failed to close NVMe device %v", b.initiator.Endpoint)
+	var errs []error
+	endpoint := getDeviceEndpoint(b.initiator, b.devFh)
+
+	var lvolName string
+	if b.replica != nil {
+		lvolName = GetReplicaSnapshotLvolName(b.replica.Name, snapshotName)
 	}
 
-	b.log.Info("Stopping NVMe initiator")
-	if _, err := b.initiator.Stop(nil, true, true, true); err != nil {
-		return errors.Wrapf(err, "failed to stop NVMe initiator")
+	if b.devFh != nil {
+		if endpoint != "" {
+			b.log.Infof("Closing NVMe device %v", endpoint)
+		} else {
+			b.log.Info("Closing NVMe device")
+		}
+		if err := b.devFh.Close(); err != nil {
+			if endpoint != "" {
+				errs = append(errs, errors.Wrapf(err, "failed to close NVMe device %v", endpoint))
+			} else {
+				errs = append(errs, errors.Wrap(err, "failed to close NVMe device"))
+			}
+		}
 	}
 
-	b.log.Info("Unexposing snapshot lvol bdev")
-	lvolName := GetReplicaSnapshotLvolName(b.replica.Name, snapshotName)
-	err := b.spdkClient.StopExposeBdev(helpertypes.GetNQN(lvolName))
-	if err != nil {
-		return errors.Wrapf(err, "failed to unexpose snapshot lvol bdev %v", lvolName)
+	if b.initiator != nil {
+		b.log.Info("Stopping NVMe initiator")
+		if _, err := b.initiator.Stop(nil, true, true, true); err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed to stop NVMe initiator"))
+		}
 	}
 
+	if lvolName != "" {
+		b.log.Info("Unexposing snapshot lvol bdev")
+		if err := backupStopExposeBdev(b.spdkClient, helpertypes.GetNQN(lvolName)); err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed to unexpose snapshot lvol bdev %v", lvolName))
+		}
+	}
+
+	b.releaseHeavyResourcesLocked()
+	b.markTerminalHandledLocked()
+
+	if len(errs) > 0 {
+		return errors.Errorf("CloseSnapshot encountered %d error(s): %v", len(errs), errs)
+	}
 	return nil
+}
+
+// markTerminalHandledLocked fires the onTerminal callback exactly once
+// after all heavy resources have been released by releaseHeavyResourcesLocked.
+// It relies on CloseSnapshot always being called (via defer) by the
+// backupstore library after the backup goroutine exits.
+func (b *Backup) markTerminalHandledLocked() {
+	if !isBackupTerminalState(b.State) || b.terminalSeen {
+		return
+	}
+
+	b.terminalSeen = true
+	if b.terminalAt.IsZero() {
+		b.terminalAt = time.Now()
+	}
+	if b.onTerminal != nil {
+		go b.onTerminal()
+	}
+}
+
+func (b *Backup) releaseHeavyResourcesLocked() {
+	if b.portAllocator != nil && b.Port != 0 {
+		if err := b.portAllocator.ReleaseRange(b.Port, b.Port); err != nil {
+			b.log.WithError(err).Warnf("Failed to release port %v", b.Port)
+		}
+		b.portAllocator = nil
+	}
+	b.fragmap = nil
+	b.initiator = nil
+	b.devFh = nil
+	b.executor = nil
+	b.subsystemNQN = ""
+	b.controllerName = ""
+	b.replica = nil
 }
 
 // UpdateBackupStatus updates the backup status. The state is first-respected, but if
@@ -262,8 +378,8 @@ func (b *Backup) UpdateBackupStatus(snapshotName, volumeName string, state strin
 	b.Lock()
 	defer b.Unlock()
 
-	if b.State == btypes.ProgressStateComplete || b.State == btypes.ProgressStateError {
-		b.log.Warnf("Backup of volume %v snapshot %v already completed or failed, skip the status update", b.VolumeName, b.SnapshotName)
+	if isBackupTerminalState(b.State) {
+		b.log.Warnf("Backup %s for volume %s is already terminal in state %s, skipping status update", b.Name, b.VolumeName, b.State)
 		return nil
 	}
 
@@ -278,7 +394,15 @@ func (b *Backup) UpdateBackupStatus(snapshotName, volumeName string, state strin
 		b.State = btypes.ProgressStateComplete
 	}
 
+	if isBackupTerminalState(b.State) && b.terminalAt.IsZero() {
+		b.terminalAt = time.Now()
+	}
+
 	return nil
+}
+
+func isBackupTerminalState(state btypes.ProgressState) bool {
+	return state == btypes.ProgressStateComplete || state == btypes.ProgressStateError
 }
 
 func (b *Backup) newFragmap() (*Fragmap, error) {

--- a/pkg/spdk/backup_test.go
+++ b/pkg/spdk/backup_test.go
@@ -1,9 +1,12 @@
 package spdk
 
 import (
-	"github.com/sirupsen/logrus"
+	"time"
 
 	btypes "github.com/longhorn/backupstore/types"
+	commonns "github.com/longhorn/go-common-libs/ns"
+	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
+	"github.com/sirupsen/logrus"
 
 	. "gopkg.in/check.v1"
 )
@@ -34,4 +37,256 @@ func (s *TestSuite) TestUpdateBackupStatusKeepsErrorAsFinalState(c *C) {
 	c.Assert(b.Progress, Equals, 42)
 	c.Assert(b.Error, Equals, "upload failed")
 	c.Assert(b.BackupURL, Equals, "")
+}
+
+func (s *TestSuite) TestBackupTerminalStatusInvokesCallbackOnce(c *C) {
+	callbackCh := make(chan struct{}, 2)
+	backup := &Backup{
+		Name:       "backup-a",
+		VolumeName: "vol-a",
+		log:        logrus.New(),
+		onTerminal: func() {
+			callbackCh <- struct{}{}
+		},
+	}
+
+	err := backup.UpdateBackupStatus("snap-a", "vol-a", string(btypes.ProgressStateInProgress), 100, "backup://target", "")
+	c.Assert(err, IsNil)
+	c.Assert(backup.State, Equals, btypes.ProgressStateComplete)
+	c.Assert(backup.terminalSeen, Equals, false)
+
+	select {
+	case <-callbackCh:
+		c.Fatal("unexpected terminal callback before cleanup")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	err = backup.CloseSnapshot("snap-a", "vol-a")
+	c.Assert(err, IsNil)
+	c.Assert(backup.terminalSeen, Equals, true)
+
+	select {
+	case <-callbackCh:
+	case <-time.After(500 * time.Millisecond):
+		c.Fatal("timed out waiting for terminal callback")
+	}
+
+	err = backup.UpdateBackupStatus("snap-a", "vol-a", string(btypes.ProgressStateInProgress), 10, "", "")
+	c.Assert(err, IsNil)
+	err = backup.CloseSnapshot("snap-a", "vol-a")
+	c.Assert(err, IsNil)
+
+	select {
+	case <-callbackCh:
+		c.Fatal("unexpected second terminal callback")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func (s *TestSuite) TestBackupTerminalCallbackRunsAfterCleanup(c *C) {
+	callbackStarted := make(chan struct{}, 1)
+	callbackDone := make(chan struct{}, 1)
+	origBackupStopExposeBdev := backupStopExposeBdev
+	defer func() {
+		backupStopExposeBdev = origBackupStopExposeBdev
+	}()
+	backupStopExposeBdev = func(_ *spdkclient.Client, _ string) error {
+		return nil
+	}
+
+	var backup *Backup
+	backup = &Backup{
+		Name:       "backup-a",
+		VolumeName: "vol-a",
+		State:      btypes.ProgressStateComplete,
+		replica:    &Replica{Name: "replica-a"},
+		fragmap:    &Fragmap{},
+		log:        logrus.New(),
+		onTerminal: func() {
+			callbackStarted <- struct{}{}
+			if backup.replica != nil || backup.fragmap != nil || backup.devFh != nil || backup.initiator != nil {
+				c.Errorf("cleanup had not completed before terminal callback ran")
+			}
+			callbackDone <- struct{}{}
+		},
+	}
+
+	err := backup.CloseSnapshot("snap-a", "vol-a")
+	c.Assert(err, IsNil)
+
+	select {
+	case <-callbackStarted:
+	case <-time.After(500 * time.Millisecond):
+		c.Fatal("timed out waiting for terminal callback start")
+	}
+
+	select {
+	case <-callbackDone:
+	case <-time.After(500 * time.Millisecond):
+		c.Fatal("timed out waiting for terminal callback completion")
+	}
+}
+
+func (s *TestSuite) TestPruneRetainedBackupsKeepsRecentTerminalStates(c *C) {
+	oldRetainCounts := retainBackupStateCounts
+	retainBackupStateCounts = map[btypes.ProgressState]int{
+		btypes.ProgressStateComplete: 2,
+		btypes.ProgressStateError:    1,
+	}
+	defer func() {
+		retainBackupStateCounts = oldRetainCounts
+	}()
+
+	server := &Server{
+		backupMap: map[string]*Backup{},
+	}
+
+	server.trackBackupLocked("complete-oldest", &Backup{
+		Name:           "complete-oldest",
+		State:          btypes.ProgressStateComplete,
+		terminalSeen:   true,
+		terminalAt:     time.Now().Add(-5 * time.Second),
+		replica:        &Replica{Name: "replica-a"},
+		fragmap:        &Fragmap{},
+		executor:       &commonns.Executor{},
+		subsystemNQN:   "nqn-oldest",
+		controllerName: "ctrl-oldest",
+	})
+	server.trackBackupLocked("complete-middle", &Backup{Name: "complete-middle", State: btypes.ProgressStateComplete, terminalSeen: true, terminalAt: time.Now().Add(-3 * time.Second)})
+	server.trackBackupLocked("complete-newest", &Backup{Name: "complete-newest", State: btypes.ProgressStateComplete, terminalSeen: true, terminalAt: time.Now().Add(-1 * time.Second)})
+	server.trackBackupLocked("error-oldest", &Backup{Name: "error-oldest", State: btypes.ProgressStateError, terminalSeen: true, terminalAt: time.Now().Add(-4 * time.Second)})
+	server.trackBackupLocked("error-newest", &Backup{Name: "error-newest", State: btypes.ProgressStateError, terminalSeen: true, terminalAt: time.Now().Add(-2 * time.Second)})
+	server.trackBackupLocked("in-progress", &Backup{Name: "in-progress", State: btypes.ProgressStateInProgress})
+
+	_, exists := server.backupMap["complete-oldest"]
+	c.Assert(exists, Equals, false)
+	_, exists = server.backupMap["error-oldest"]
+	c.Assert(exists, Equals, false)
+
+	_, exists = server.backupMap["complete-middle"]
+	c.Assert(exists, Equals, true)
+	_, exists = server.backupMap["complete-newest"]
+	c.Assert(exists, Equals, true)
+	_, exists = server.backupMap["error-newest"]
+	c.Assert(exists, Equals, true)
+	_, exists = server.backupMap["in-progress"]
+	c.Assert(exists, Equals, true)
+}
+
+func (s *TestSuite) TestPruneRetainedBackupsReleasesHeavyResourcesBeforeDeletion(c *C) {
+	oldRetainCounts := retainBackupStateCounts
+	retainBackupStateCounts = map[btypes.ProgressState]int{
+		btypes.ProgressStateComplete: 0,
+		btypes.ProgressStateError:    0,
+	}
+	defer func() {
+		retainBackupStateCounts = oldRetainCounts
+	}()
+
+	server := &Server{
+		backupMap: map[string]*Backup{},
+	}
+
+	evicted := &Backup{
+		Name:           "complete-old",
+		State:          btypes.ProgressStateComplete,
+		terminalSeen:   true,
+		terminalAt:     time.Now(),
+		replica:        &Replica{Name: "replica-a"},
+		fragmap:        &Fragmap{},
+		executor:       &commonns.Executor{},
+		subsystemNQN:   "nqn-evicted",
+		controllerName: "ctrl-evicted",
+	}
+	server.trackBackupLocked(evicted.Name, evicted)
+
+	c.Assert(evicted.fragmap, IsNil)
+	c.Assert(evicted.executor, IsNil)
+	c.Assert(evicted.replica, IsNil)
+	c.Assert(evicted.subsystemNQN, Equals, "")
+	c.Assert(evicted.controllerName, Equals, "")
+	_, exists := server.backupMap[evicted.Name]
+	c.Assert(exists, Equals, false)
+}
+
+// TestOnBackupTerminalPrunesByTerminalTime verifies that when two backups are
+// created in order A, B but B completes before A, pruning evicts B (the earlier
+// completion) rather than A, regardless of goroutine scheduling order.
+func (s *TestSuite) TestOnBackupTerminalPrunesByTerminalTime(c *C) {
+	oldRetainCounts := retainBackupStateCounts
+	retainBackupStateCounts = map[btypes.ProgressState]int{
+		btypes.ProgressStateComplete: 1,
+	}
+	defer func() {
+		retainBackupStateCounts = oldRetainCounts
+	}()
+
+	server := &Server{
+		backupMap: map[string]*Backup{},
+	}
+
+	// Create A then B.
+	backupA := &Backup{Name: "A", State: btypes.ProgressStateInProgress}
+	backupB := &Backup{Name: "B", State: btypes.ProgressStateInProgress}
+	server.trackBackupLocked("A", backupA)
+	server.trackBackupLocked("B", backupB)
+
+	// B completes first via the real status-update path.
+	err := backupB.UpdateBackupStatus("snap", "vol", string(btypes.ProgressStateInProgress), 100, "", "")
+	c.Assert(err, IsNil)
+	c.Assert(backupB.State, Equals, btypes.ProgressStateComplete)
+	c.Assert(backupB.terminalAt.IsZero(), Equals, false)
+	bTime := backupB.terminalAt
+
+	// Small delay so A gets a strictly later terminalAt.
+	time.Sleep(5 * time.Millisecond)
+
+	// A completes second via the real status-update path.
+	err = backupA.UpdateBackupStatus("snap", "vol", string(btypes.ProgressStateInProgress), 100, "", "")
+	c.Assert(err, IsNil)
+	c.Assert(backupA.State, Equals, btypes.ProgressStateComplete)
+	c.Assert(backupA.terminalAt.IsZero(), Equals, false)
+	c.Assert(backupA.terminalAt.After(bTime), Equals, true)
+	backupB.terminalSeen = true
+	backupA.terminalSeen = true
+
+	// Simulate callbacks arriving in any order — only prune matters.
+	server.onBackupTerminalLocked()
+
+	// Retain limit is 1: A (the most recently completed) must survive; B must be evicted.
+	_, existsA := server.backupMap["A"]
+	c.Assert(existsA, Equals, true)
+	_, existsB := server.backupMap["B"]
+	c.Assert(existsB, Equals, false)
+}
+
+func (s *TestSuite) TestPruneRetainedBackupsSkipsTerminalBackupsBeforeCleanup(c *C) {
+	oldRetainCounts := retainBackupStateCounts
+	retainBackupStateCounts = map[btypes.ProgressState]int{
+		btypes.ProgressStateComplete: 0,
+	}
+	defer func() {
+		retainBackupStateCounts = oldRetainCounts
+	}()
+
+	server := &Server{
+		backupMap: map[string]*Backup{},
+	}
+
+	backup := &Backup{
+		Name:       "complete-not-cleaned",
+		State:      btypes.ProgressStateComplete,
+		terminalAt: time.Now(),
+		replica:    &Replica{Name: "replica-a"},
+		fragmap:    &Fragmap{},
+		executor:   &commonns.Executor{},
+	}
+
+	server.trackBackupLocked(backup.Name, backup)
+
+	_, exists := server.backupMap[backup.Name]
+	c.Assert(exists, Equals, true)
+	c.Assert(backup.replica, NotNil)
+	c.Assert(backup.fragmap, NotNil)
+	c.Assert(backup.executor, NotNil)
 }

--- a/pkg/spdk/backup_test.go
+++ b/pkg/spdk/backup_test.go
@@ -1,9 +1,11 @@
 package spdk
 
 import (
+	"errors"
 	"time"
 
 	btypes "github.com/longhorn/backupstore/types"
+	commonbitmap "github.com/longhorn/go-common-libs/bitmap"
 	commonns "github.com/longhorn/go-common-libs/ns"
 	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
 	"github.com/sirupsen/logrus"
@@ -37,6 +39,16 @@ func (s *TestSuite) TestUpdateBackupStatusKeepsErrorAsFinalState(c *C) {
 	c.Assert(b.Progress, Equals, 42)
 	c.Assert(b.Error, Equals, "upload failed")
 	c.Assert(b.BackupURL, Equals, "")
+}
+
+type failingStopNVMeInitiator struct {
+	fakeNVMeInitiator
+	stopErr error
+}
+
+func (f *failingStopNVMeInitiator) Stop(_ *spdkclient.Client, _ bool, _ bool, _ bool) (bool, error) {
+	f.stopCalled = true
+	return false, f.stopErr
 }
 
 func (s *TestSuite) TestBackupTerminalStatusInvokesCallbackOnce(c *C) {
@@ -127,6 +139,165 @@ func (s *TestSuite) TestBackupTerminalCallbackRunsAfterCleanup(c *C) {
 	}
 }
 
+func (s *TestSuite) TestBackupCloseSnapshotDoesNotMarkTerminalOnCleanupFailure(c *C) {
+	callbackCh := make(chan struct{}, 1)
+	origBackupStopExposeBdev := backupStopExposeBdev
+	defer func() {
+		backupStopExposeBdev = origBackupStopExposeBdev
+	}()
+	backupStopExposeBdev = func(_ *spdkclient.Client, _ string) error {
+		return nil
+	}
+
+	fakeInitiator := &failingStopNVMeInitiator{
+		fakeNVMeInitiator: fakeNVMeInitiator{endpoint: "/dev/fake-backup"},
+		stopErr:           errors.New("stop failed"),
+	}
+
+	backup := &Backup{
+		Name:           "backup-a",
+		VolumeName:     "vol-a",
+		State:          btypes.ProgressStateComplete,
+		replica:        &Replica{Name: "replica-a"},
+		fragmap:        &Fragmap{},
+		subsystemNQN:   "nqn-a",
+		controllerName: "ctrl-a",
+		initiator:      fakeInitiator,
+		log:            logrus.New(),
+		onTerminal: func() {
+			callbackCh <- struct{}{}
+		},
+	}
+
+	err := backup.CloseSnapshot("snap-a", "vol-a")
+	c.Assert(err, NotNil)
+	c.Assert(backup.terminalSeen, Equals, false)
+	c.Assert(backup.initiator, Equals, nvmeInitiator(fakeInitiator))
+
+	select {
+	case <-callbackCh:
+		c.Fatal("unexpected terminal callback after cleanup failure")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func (s *TestSuite) TestBackupCloseSnapshotDoesNotMarkTerminalOnPortReleaseFailure(c *C) {
+	callbackCh := make(chan struct{}, 1)
+	origBackupStopExposeBdev := backupStopExposeBdev
+	defer func() {
+		backupStopExposeBdev = origBackupStopExposeBdev
+	}()
+	backupStopExposeBdev = func(_ *spdkclient.Client, _ string) error {
+		return nil
+	}
+
+	portAllocator, err := commonbitmap.NewBitmap(100, 100)
+	c.Assert(err, IsNil)
+
+	backup := &Backup{
+		Name:       "backup-a",
+		VolumeName: "vol-a",
+		State:      btypes.ProgressStateComplete,
+		Port:       200,
+		fragmap:    &Fragmap{},
+		executor:   &commonns.Executor{},
+		replica:    &Replica{Name: "replica-a"},
+		log:        logrus.New(),
+		onTerminal: func() {
+			callbackCh <- struct{}{}
+		},
+		portAllocator: portAllocator,
+	}
+
+	err = backup.CloseSnapshot("snap-a", "vol-a")
+	c.Assert(err, NotNil)
+	c.Assert(backup.terminalSeen, Equals, false)
+	c.Assert(backup.portAllocator, NotNil)
+	c.Assert(backup.replica, NotNil)
+
+	select {
+	case <-callbackCh:
+		c.Fatal("unexpected terminal callback after port release failure")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestBackupCreateFailureRetainsMapEntryWhenResourcesActive simulates the
+// server_replica.go BackupCreate error path: if releaseHeavyResourcesLocked
+// cannot fully clean up (active snapshot resources remain), the backup must
+// stay in the map with an error state so it remains discoverable.
+func (s *TestSuite) TestBackupCreateFailureRetainsMapEntryWhenResourcesActive(c *C) {
+	server := &Server{
+		backupMap: map[string]*Backup{},
+	}
+
+	// Backup with active resources (initiator still connected).
+	backup := &Backup{
+		Name:         "backup-leak",
+		VolumeName:   "vol-a",
+		State:        btypes.ProgressStateInProgress,
+		replica:      &Replica{Name: "replica-a"},
+		initiator:    &fakeNVMeInitiator{endpoint: "/dev/fake"},
+		subsystemNQN: "nqn-leak",
+		log:          logrus.New(),
+	}
+	server.trackBackupLocked("backup-leak", backup)
+
+	// Simulate the BackupCreate failure path in server_replica.go:
+	// releaseHeavyResourcesLocked, then conditionally remove from map.
+	backup.Lock()
+	backup.releaseHeavyResourcesLocked()
+	c.Assert(backup.hasActiveSnapshotResourcesLocked(), Equals, true)
+
+	backup.State = btypes.ProgressStateError
+	backup.Error = "simulated create failure"
+	if backup.terminalAt.IsZero() {
+		backup.terminalAt = time.Now()
+	}
+	backup.markTerminalHandledLocked()
+	backup.Unlock()
+
+	// Backup must remain in the map and be marked terminal so it is
+	// eligible for pruning once resources are cleaned up.
+	_, exists := server.backupMap["backup-leak"]
+	c.Assert(exists, Equals, true)
+	c.Assert(backup.State, Equals, btypes.ProgressStateError)
+	c.Assert(backup.terminalSeen, Equals, true)
+	c.Assert(backup.initiator, NotNil)
+	c.Assert(backup.subsystemNQN, Equals, "nqn-leak")
+}
+
+// TestBackupCreateFailureRemovesMapEntryWhenClean verifies that when
+// releaseHeavyResourcesLocked fully cleans up, the backup is removed
+// from the map as before.
+func (s *TestSuite) TestBackupCreateFailureRemovesMapEntryWhenClean(c *C) {
+	server := &Server{
+		backupMap: map[string]*Backup{},
+	}
+
+	// Backup with no active snapshot resources.
+	backup := &Backup{
+		Name:       "backup-clean",
+		VolumeName: "vol-a",
+		State:      btypes.ProgressStateInProgress,
+		replica:    &Replica{Name: "replica-a"},
+		fragmap:    &Fragmap{},
+		log:        logrus.New(),
+	}
+	server.trackBackupLocked("backup-clean", backup)
+
+	backup.Lock()
+	backup.releaseHeavyResourcesLocked()
+	hasActive := backup.hasActiveSnapshotResourcesLocked()
+	backup.Unlock()
+
+	c.Assert(hasActive, Equals, false)
+	server.removeBackupLocked("backup-clean")
+
+	_, exists := server.backupMap["backup-clean"]
+	c.Assert(exists, Equals, false)
+}
+
 func (s *TestSuite) TestPruneRetainedBackupsKeepsRecentTerminalStates(c *C) {
 	oldRetainCounts := retainBackupStateCounts
 	retainBackupStateCounts = map[btypes.ProgressState]int{
@@ -142,15 +313,13 @@ func (s *TestSuite) TestPruneRetainedBackupsKeepsRecentTerminalStates(c *C) {
 	}
 
 	server.trackBackupLocked("complete-oldest", &Backup{
-		Name:           "complete-oldest",
-		State:          btypes.ProgressStateComplete,
-		terminalSeen:   true,
-		terminalAt:     time.Now().Add(-5 * time.Second),
-		replica:        &Replica{Name: "replica-a"},
-		fragmap:        &Fragmap{},
-		executor:       &commonns.Executor{},
-		subsystemNQN:   "nqn-oldest",
-		controllerName: "ctrl-oldest",
+		Name:         "complete-oldest",
+		State:        btypes.ProgressStateComplete,
+		terminalSeen: true,
+		terminalAt:   time.Now().Add(-5 * time.Second),
+		replica:      &Replica{Name: "replica-a"},
+		fragmap:      &Fragmap{},
+		executor:     &commonns.Executor{},
 	})
 	server.trackBackupLocked("complete-middle", &Backup{Name: "complete-middle", State: btypes.ProgressStateComplete, terminalSeen: true, terminalAt: time.Now().Add(-3 * time.Second)})
 	server.trackBackupLocked("complete-newest", &Backup{Name: "complete-newest", State: btypes.ProgressStateComplete, terminalSeen: true, terminalAt: time.Now().Add(-1 * time.Second)})
@@ -188,15 +357,13 @@ func (s *TestSuite) TestPruneRetainedBackupsReleasesHeavyResourcesBeforeDeletion
 	}
 
 	evicted := &Backup{
-		Name:           "complete-old",
-		State:          btypes.ProgressStateComplete,
-		terminalSeen:   true,
-		terminalAt:     time.Now(),
-		replica:        &Replica{Name: "replica-a"},
-		fragmap:        &Fragmap{},
-		executor:       &commonns.Executor{},
-		subsystemNQN:   "nqn-evicted",
-		controllerName: "ctrl-evicted",
+		Name:         "complete-old",
+		State:        btypes.ProgressStateComplete,
+		terminalSeen: true,
+		terminalAt:   time.Now(),
+		replica:      &Replica{Name: "replica-a"},
+		fragmap:      &Fragmap{},
+		executor:     &commonns.Executor{},
 	}
 	server.trackBackupLocked(evicted.Name, evicted)
 
@@ -207,6 +374,40 @@ func (s *TestSuite) TestPruneRetainedBackupsReleasesHeavyResourcesBeforeDeletion
 	c.Assert(evicted.controllerName, Equals, "")
 	_, exists := server.backupMap[evicted.Name]
 	c.Assert(exists, Equals, false)
+}
+
+func (s *TestSuite) TestPruneRetainedBackupsSkipsTerminalBackupsWithActiveSnapshotResources(c *C) {
+	oldRetainCounts := retainBackupStateCounts
+	retainBackupStateCounts = map[btypes.ProgressState]int{
+		btypes.ProgressStateComplete: 0,
+	}
+	defer func() {
+		retainBackupStateCounts = oldRetainCounts
+	}()
+
+	server := &Server{
+		backupMap: map[string]*Backup{},
+	}
+
+	backup := &Backup{
+		Name:         "complete-active",
+		State:        btypes.ProgressStateComplete,
+		terminalSeen: true,
+		terminalAt:   time.Now(),
+		replica:      &Replica{Name: "replica-a"},
+		fragmap:      &Fragmap{},
+		executor:     &commonns.Executor{},
+		subsystemNQN: "nqn-active",
+	}
+	server.trackBackupLocked(backup.Name, backup)
+
+	server.pruneRetainedBackupsLocked()
+
+	_, exists := server.backupMap[backup.Name]
+	c.Assert(exists, Equals, true)
+	c.Assert(backup.replica, NotNil)
+	c.Assert(backup.fragmap, NotNil)
+	c.Assert(backup.executor, NotNil)
 }
 
 // TestOnBackupTerminalPrunesByTerminalTime verifies that when two backups are

--- a/pkg/spdk/io_hooks.go
+++ b/pkg/spdk/io_hooks.go
@@ -1,0 +1,85 @@
+package spdk
+
+import (
+	"os"
+
+	commonnet "github.com/longhorn/go-common-libs/net"
+	commonns "github.com/longhorn/go-common-libs/ns"
+	"github.com/longhorn/go-spdk-helper/pkg/initiator"
+	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
+	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
+	helperutil "github.com/longhorn/go-spdk-helper/pkg/util"
+
+	lhclient "github.com/longhorn/longhorn-spdk-engine/pkg/client"
+)
+
+type nvmeInitiator interface {
+	StartNvmeTCPInitiator(transportAddress, transportServiceID string, dmDeviceAndEndpointCleanupRequired bool, stop bool) (bool, error)
+	Stop(spdkClient *spdkclient.Client, dmDeviceAndEndpointCleanupRequired, deferDmDeviceCleanup, returnErrorForBusyDevice bool) (bool, error)
+	Endpoint() string
+}
+
+type realNVMeInitiator struct {
+	*initiator.Initiator
+}
+
+func (i *realNVMeInitiator) Endpoint() string {
+	return i.Initiator.Endpoint
+}
+
+type backingImageServiceClient interface {
+	BackingImageExpose(name, lvsUUID string) (string, error)
+	BackingImageUnexpose(name, lvsUUID string) error
+	Close() error
+}
+
+// NOTE: These package-level hook variables are replaced in tests.
+// They are NOT safe for parallel test execution.
+var (
+	openFile = os.OpenFile
+
+	newNVMeTCPInitiator = func(name string, nvmeTCPInfo *initiator.NVMeTCPInfo) (nvmeInitiator, error) {
+		i, err := initiator.NewInitiator(name, initiator.HostProc, nvmeTCPInfo, nil)
+		if err != nil {
+			return nil, err
+		}
+		return &realNVMeInitiator{Initiator: i}, nil
+	}
+
+	backupNewFragmap = func(b *Backup) (*Fragmap, error) {
+		return b.newFragmap()
+	}
+	backupExposeSnapshotLvolBdev = exposeSnapshotLvolBdev
+	backupStopExposeBdev         = func(cli *spdkclient.Client, nqn string) error { return cli.StopExposeBdev(nqn) }
+
+	restoreExposeSnapshotLvolBdev = exposeSnapshotLvolBdev
+	restoreStopExposeBdev         = func(cli *spdkclient.Client, nqn string) error { return cli.StopExposeBdev(nqn) }
+
+	backingImageGetIPForPod = commonnet.GetIPForPod
+	backingImageNewExecutor = func(hostProc string) (*commonns.Executor, error) {
+		return helperutil.NewExecutor(hostProc)
+	}
+	backingImageGetLvsNameByUUID = GetLvsNameByUUID
+	backingImageBdevLvolCreate   = func(cli *spdkclient.Client, lvstoreName, lvstoreUUID, lvolName string, sizeInMib uint64, clearMethod spdktypes.BdevLvolClearMethod, thinProvision bool) (string, error) {
+		return cli.BdevLvolCreate(lvstoreName, lvstoreUUID, lvolName, sizeInMib, clearMethod, thinProvision)
+	}
+	backingImageBdevLvolGet = func(cli *spdkclient.Client, name string, timeout uint64) ([]spdktypes.BdevInfo, error) {
+		return cli.BdevLvolGet(name, timeout)
+	}
+	backingImageExposeSnapshotLvolBdev       = exposeSnapshotLvolBdev
+	backingImageStopExposeBdev               = func(cli *spdkclient.Client, nqn string) error { return cli.StopExposeBdev(nqn) }
+	backingImageGetServiceClient             = func(address string) (backingImageServiceClient, error) { return GetServiceClient(address) }
+	backingImageDiscoverAndConnectNVMeTarget = discoverAndConnectNVMeTarget
+)
+
+var _ backingImageServiceClient = (*lhclient.SPDKClient)(nil)
+
+func getDeviceEndpoint(i nvmeInitiator, fh *os.File) string {
+	if i != nil {
+		return i.Endpoint()
+	}
+	if fh != nil {
+		return fh.Name()
+	}
+	return ""
+}

--- a/pkg/spdk/io_hooks.go
+++ b/pkg/spdk/io_hooks.go
@@ -3,9 +3,10 @@ package spdk
 import (
 	"os"
 
+	"github.com/longhorn/go-spdk-helper/pkg/initiator"
+
 	commonnet "github.com/longhorn/go-common-libs/net"
 	commonns "github.com/longhorn/go-common-libs/ns"
-	"github.com/longhorn/go-spdk-helper/pkg/initiator"
 	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
 	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
 	helperutil "github.com/longhorn/go-spdk-helper/pkg/util"

--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -4062,14 +4062,6 @@ func (r *Replica) BackupRestore(spdkClient *spdkclient.Client, backupUrl, snapsh
 
 	isFullRestore := newRestore.LastRestored == ""
 
-	defer func() {
-		go func() {
-			if err := r.completeBackupRestore(spdkClient, isFullRestore); err != nil {
-				r.log.WithError(err).Warn("Replica failed to complete backup restore")
-			}
-		}()
-	}()
-
 	if isFullRestore {
 		r.log.Infof("Starting a new full restore for backup %v", backupUrl)
 		if err := r.backupRestore(backupUrl, newRestore.LvolName, concurrentLimit); err != nil {
@@ -4083,6 +4075,12 @@ func (r *Replica) BackupRestore(spdkClient *spdkclient.Client, backupUrl, snapsh
 		}
 		r.log.Infof("Successfully initiated incremental restore for %v to %v", backupUrl, newRestore.LvolName)
 	}
+
+	go func() {
+		if err := r.completeBackupRestore(spdkClient, isFullRestore); err != nil {
+			r.log.WithError(err).Warn("Replica failed to complete backup restore")
+		}
+	}()
 
 	return nil
 

--- a/pkg/spdk/resource_cleanup_test.go
+++ b/pkg/spdk/resource_cleanup_test.go
@@ -1,0 +1,409 @@
+package spdk
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	commonbitmap "github.com/longhorn/go-common-libs/bitmap"
+	commonns "github.com/longhorn/go-common-libs/ns"
+	"github.com/sirupsen/logrus"
+
+	"github.com/longhorn/go-spdk-helper/pkg/initiator"
+	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
+	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
+	helpertypes "github.com/longhorn/go-spdk-helper/pkg/types"
+
+	safelog "github.com/longhorn/longhorn-spdk-engine/pkg/log"
+
+	. "gopkg.in/check.v1"
+)
+
+type fakeNVMeInitiator struct {
+	endpoint    string
+	startCalled bool
+	stopCalled  bool
+}
+
+func (f *fakeNVMeInitiator) StartNvmeTCPInitiator(_, _ string, _ bool, _ bool) (bool, error) {
+	f.startCalled = true
+	return false, nil
+}
+
+func (f *fakeNVMeInitiator) Stop(_ *spdkclient.Client, _ bool, _ bool, _ bool) (bool, error) {
+	f.stopCalled = true
+	return false, nil
+}
+
+func (f *fakeNVMeInitiator) Endpoint() string {
+	return f.endpoint
+}
+
+type fakeBackingImageServiceClient struct {
+	exposedAddress string
+	exposeCalled   bool
+	unexposeCalled bool
+	closeCalled    bool
+}
+
+func (f *fakeBackingImageServiceClient) BackingImageExpose(_, _ string) (string, error) {
+	f.exposeCalled = true
+	return f.exposedAddress, nil
+}
+
+func (f *fakeBackingImageServiceClient) BackingImageUnexpose(_, _ string) error {
+	f.unexposeCalled = true
+	return nil
+}
+
+func (f *fakeBackingImageServiceClient) Close() error {
+	f.closeCalled = true
+	return nil
+}
+
+func (s *TestSuite) TestBackupOpenSnapshotCleansUpOnOpenFileFailure(c *C) {
+	c.Log("Testing Backup.OpenSnapshot cleans up initiator and exposure when device open fails")
+
+	origOpenFile := openFile
+	origNewNVMeTCPInitiator := newNVMeTCPInitiator
+	origBackupNewFragmap := backupNewFragmap
+	origBackupExposeSnapshotLvolBdev := backupExposeSnapshotLvolBdev
+	origBackupStopExposeBdev := backupStopExposeBdev
+	defer func() {
+		openFile = origOpenFile
+		newNVMeTCPInitiator = origNewNVMeTCPInitiator
+		backupNewFragmap = origBackupNewFragmap
+		backupExposeSnapshotLvolBdev = origBackupExposeSnapshotLvolBdev
+		backupStopExposeBdev = origBackupStopExposeBdev
+	}()
+
+	fakeInitiator := &fakeNVMeInitiator{endpoint: "/dev/fake-backup"}
+	stopExposeCalled := false
+	stopExposeNQN := ""
+
+	openFile = func(string, int, os.FileMode) (*os.File, error) {
+		return nil, fmt.Errorf("open failed")
+	}
+	newNVMeTCPInitiator = func(string, *initiator.NVMeTCPInfo) (nvmeInitiator, error) {
+		return fakeInitiator, nil
+	}
+	backupNewFragmap = func(*Backup) (*Fragmap, error) {
+		return &Fragmap{}, nil
+	}
+	backupExposeSnapshotLvolBdev = func(*spdkclient.Client, string, string, string, int32, *commonns.Executor) (string, string, error) {
+		return "subsystem", "controller", nil
+	}
+	backupStopExposeBdev = func(_ *spdkclient.Client, nqn string) error {
+		stopExposeCalled = true
+		stopExposeNQN = nqn
+		return nil
+	}
+
+	backup := &Backup{
+		spdkClient:     nil,
+		VolumeName:     "vol-a",
+		replica:        &Replica{Name: "replica-a", LvsName: "disk-a"},
+		IP:             "10.0.0.1",
+		Port:           1000,
+		log:            logrus.New(),
+		subsystemNQN:   "stale-subsystem",
+		controllerName: "stale-controller",
+	}
+
+	err := backup.OpenSnapshot("snap-a", "vol-a")
+	c.Assert(err, NotNil)
+	c.Assert(fakeInitiator.startCalled, Equals, true)
+	c.Assert(fakeInitiator.stopCalled, Equals, true)
+	c.Assert(stopExposeCalled, Equals, true)
+	c.Assert(stopExposeNQN, Equals, helpertypes.GetNQN(GetReplicaSnapshotLvolName("replica-a", "snap-a")))
+	c.Assert(backup.initiator, IsNil)
+	c.Assert(backup.devFh, IsNil)
+	c.Assert(backup.subsystemNQN, Equals, "")
+	c.Assert(backup.controllerName, Equals, "")
+}
+
+func (s *TestSuite) TestRestoreOpenVolumeDevCleansUpOnOpenFileFailure(c *C) {
+	c.Log("Testing Restore.OpenVolumeDev cleans up initiator and exposure when device open fails")
+
+	origOpenFile := openFile
+	origNewNVMeTCPInitiator := newNVMeTCPInitiator
+	origRestoreExposeSnapshotLvolBdev := restoreExposeSnapshotLvolBdev
+	origRestoreStopExposeBdev := restoreStopExposeBdev
+	defer func() {
+		openFile = origOpenFile
+		newNVMeTCPInitiator = origNewNVMeTCPInitiator
+		restoreExposeSnapshotLvolBdev = origRestoreExposeSnapshotLvolBdev
+		restoreStopExposeBdev = origRestoreStopExposeBdev
+	}()
+
+	fakeInitiator := &fakeNVMeInitiator{endpoint: "/dev/fake-restore"}
+	stopExposeCalled := false
+	stopExposeNQN := ""
+
+	openFile = func(string, int, os.FileMode) (*os.File, error) {
+		return nil, fmt.Errorf("open failed")
+	}
+	newNVMeTCPInitiator = func(string, *initiator.NVMeTCPInfo) (nvmeInitiator, error) {
+		return fakeInitiator, nil
+	}
+	restoreExposeSnapshotLvolBdev = func(*spdkclient.Client, string, string, string, int32, *commonns.Executor) (string, string, error) {
+		return "subsystem", "controller", nil
+	}
+	restoreStopExposeBdev = func(_ *spdkclient.Client, nqn string) error {
+		stopExposeCalled = true
+		stopExposeNQN = nqn
+		return nil
+	}
+
+	replica := &Replica{Name: "replica-a", LvsName: "disk-a", IsExposed: false}
+	restore := &Restore{
+		spdkClient: nil,
+		replica:    replica,
+		ip:         "10.0.0.1",
+		port:       1000,
+		log:        logrus.New(),
+	}
+
+	fh, endpoint, err := restore.OpenVolumeDev("unused")
+	c.Assert(err, NotNil)
+	c.Assert(fh, IsNil)
+	c.Assert(endpoint, Equals, "")
+	c.Assert(fakeInitiator.startCalled, Equals, true)
+	c.Assert(fakeInitiator.stopCalled, Equals, true)
+	c.Assert(stopExposeCalled, Equals, true)
+	c.Assert(stopExposeNQN, Equals, helpertypes.GetNQN("replica-a"))
+	c.Assert(restore.initiator, IsNil)
+	c.Assert(replica.IsExposed, Equals, false)
+}
+
+func (s *TestSuite) TestRestoreOpenVolumeDevUnexposeFailureKeepsIsExposed(c *C) {
+	c.Log("Testing Restore.OpenVolumeDev keeps IsExposed=true when unexpose fails during cleanup")
+
+	origOpenFile := openFile
+	origNewNVMeTCPInitiator := newNVMeTCPInitiator
+	origRestoreExposeSnapshotLvolBdev := restoreExposeSnapshotLvolBdev
+	origRestoreStopExposeBdev := restoreStopExposeBdev
+	defer func() {
+		openFile = origOpenFile
+		newNVMeTCPInitiator = origNewNVMeTCPInitiator
+		restoreExposeSnapshotLvolBdev = origRestoreExposeSnapshotLvolBdev
+		restoreStopExposeBdev = origRestoreStopExposeBdev
+	}()
+
+	fakeInitiator := &fakeNVMeInitiator{endpoint: "/dev/fake-restore"}
+
+	openFile = func(string, int, os.FileMode) (*os.File, error) {
+		return nil, fmt.Errorf("open failed")
+	}
+	newNVMeTCPInitiator = func(string, *initiator.NVMeTCPInfo) (nvmeInitiator, error) {
+		return fakeInitiator, nil
+	}
+	restoreExposeSnapshotLvolBdev = func(*spdkclient.Client, string, string, string, int32, *commonns.Executor) (string, string, error) {
+		return "subsystem", "controller", nil
+	}
+	restoreStopExposeBdev = func(_ *spdkclient.Client, nqn string) error {
+		return fmt.Errorf("unexpose failed")
+	}
+
+	replica := &Replica{Name: "replica-a", LvsName: "disk-a", IsExposed: false}
+	restore := &Restore{
+		spdkClient: nil,
+		replica:    replica,
+		ip:         "10.0.0.1",
+		port:       1000,
+		log:        logrus.New(),
+	}
+
+	fh, endpoint, err := restore.OpenVolumeDev("unused")
+	c.Assert(err, NotNil)
+	c.Assert(fh, IsNil)
+	c.Assert(endpoint, Equals, "")
+	// IsExposed must remain true because unexpose failed
+	c.Assert(replica.IsExposed, Equals, true)
+}
+
+func (s *TestSuite) TestBackupCloseSnapshotHandlesMissingInitiator(c *C) {
+	c.Log("Testing Backup.CloseSnapshot tolerates a missing initiator during cleanup")
+
+	origBackupStopExposeBdev := backupStopExposeBdev
+	defer func() {
+		backupStopExposeBdev = origBackupStopExposeBdev
+	}()
+
+	stopExposeCalled := false
+	backupStopExposeBdev = func(_ *spdkclient.Client, nqn string) error {
+		stopExposeCalled = true
+		c.Assert(nqn, Equals, helpertypes.GetNQN(GetReplicaSnapshotLvolName("replica-a", "snap-a")))
+		return nil
+	}
+
+	fh, err := os.CreateTemp(c.MkDir(), "backup-close-*")
+	c.Assert(err, IsNil)
+
+	backup := &Backup{
+		spdkClient: nil,
+		replica:    &Replica{Name: "replica-a"},
+		devFh:      fh,
+		log:        logrus.New(),
+	}
+
+	err = backup.CloseSnapshot("snap-a", "vol-a")
+	c.Assert(err, IsNil)
+	c.Assert(stopExposeCalled, Equals, true)
+	c.Assert(backup.devFh, IsNil)
+	c.Assert(backup.initiator, IsNil)
+	c.Assert(backup.replica, IsNil)
+}
+
+func (s *TestSuite) TestRestoreCloseVolumeDevHandlesMissingInitiator(c *C) {
+	c.Log("Testing Restore.CloseVolumeDev tolerates a missing initiator during cleanup")
+
+	origRestoreStopExposeBdev := restoreStopExposeBdev
+	defer func() {
+		restoreStopExposeBdev = origRestoreStopExposeBdev
+	}()
+
+	stopExposeCalled := false
+	restoreStopExposeBdev = func(_ *spdkclient.Client, nqn string) error {
+		stopExposeCalled = true
+		c.Assert(nqn, Equals, helpertypes.GetNQN("replica-a"))
+		return nil
+	}
+
+	volDev, err := os.CreateTemp(c.MkDir(), "restore-close-*")
+	c.Assert(err, IsNil)
+
+	replica := &Replica{Name: "replica-a", IsExposed: true}
+	restore := &Restore{
+		spdkClient: nil,
+		replica:    replica,
+		log:        logrus.New(),
+	}
+
+	err = restore.CloseVolumeDev(volDev)
+	c.Assert(err, IsNil)
+	c.Assert(stopExposeCalled, Equals, true)
+	c.Assert(replica.IsExposed, Equals, false)
+	c.Assert(restore.initiator, IsNil)
+}
+
+func (s *TestSuite) TestPrepareBackingImageSnapshotOpenFileFailureStopsInitiator(c *C) {
+	c.Log("Testing prepareBackingImageSnapshot stops initiator when device open fails")
+
+	origOpenFile := openFile
+	origNewNVMeTCPInitiator := newNVMeTCPInitiator
+	origBackingImageGetIPForPod := backingImageGetIPForPod
+	origBackingImageNewExecutor := backingImageNewExecutor
+	origBackingImageGetLvsNameByUUID := backingImageGetLvsNameByUUID
+	origBackingImageBdevLvolCreate := backingImageBdevLvolCreate
+	origBackingImageBdevLvolGet := backingImageBdevLvolGet
+	origBackingImageExposeSnapshotLvolBdev := backingImageExposeSnapshotLvolBdev
+	origBackingImageStopExposeBdev := backingImageStopExposeBdev
+	defer func() {
+		openFile = origOpenFile
+		newNVMeTCPInitiator = origNewNVMeTCPInitiator
+		backingImageGetIPForPod = origBackingImageGetIPForPod
+		backingImageNewExecutor = origBackingImageNewExecutor
+		backingImageGetLvsNameByUUID = origBackingImageGetLvsNameByUUID
+		backingImageBdevLvolCreate = origBackingImageBdevLvolCreate
+		backingImageBdevLvolGet = origBackingImageBdevLvolGet
+		backingImageExposeSnapshotLvolBdev = origBackingImageExposeSnapshotLvolBdev
+		backingImageStopExposeBdev = origBackingImageStopExposeBdev
+	}()
+
+	fakeInitiator := &fakeNVMeInitiator{endpoint: "/dev/fake-bi-head"}
+	stopExposeCalled := false
+	openFile = func(string, int, os.FileMode) (*os.File, error) {
+		return nil, fmt.Errorf("open failed")
+	}
+	newNVMeTCPInitiator = func(string, *initiator.NVMeTCPInfo) (nvmeInitiator, error) {
+		return fakeInitiator, nil
+	}
+	backingImageGetIPForPod = func() (string, error) {
+		return "10.0.0.1", nil
+	}
+	backingImageNewExecutor = func(string) (*commonns.Executor, error) {
+		return nil, nil
+	}
+	backingImageGetLvsNameByUUID = func(*spdkclient.Client, string) (string, error) {
+		return "disk-a", nil
+	}
+	backingImageBdevLvolCreate = func(*spdkclient.Client, string, string, string, uint64, spdktypes.BdevLvolClearMethod, bool) (string, error) {
+		return "", nil
+	}
+	backingImageBdevLvolGet = func(*spdkclient.Client, string, uint64) ([]spdktypes.BdevInfo, error) {
+		return []spdktypes.BdevInfo{{
+			BdevInfoBasic: spdktypes.BdevInfoBasic{Name: "bi-temp-head"},
+		}}, nil
+	}
+	backingImageExposeSnapshotLvolBdev = func(*spdkclient.Client, string, string, string, int32, *commonns.Executor) (string, string, error) {
+		return "subsystem", "controller", nil
+	}
+	backingImageStopExposeBdev = func(*spdkclient.Client, string) error {
+		stopExposeCalled = true
+		return nil
+	}
+
+	portAllocator, err := commonbitmap.NewBitmap(1000, 1000)
+	c.Assert(err, IsNil)
+
+	bi := &BackingImage{
+		ctx:     context.Background(),
+		Name:    "bi-a",
+		LvsName: "disk-a",
+		LvsUUID: "uuid-a",
+		log:     safelog.NewSafeLogger(logrus.New()),
+	}
+
+	err = bi.prepareBackingImageSnapshot(nil, portAllocator, "http://example.com/image.raw", "")
+	c.Assert(err, NotNil)
+	c.Assert(fakeInitiator.startCalled, Equals, true)
+	c.Assert(fakeInitiator.stopCalled, Equals, true)
+	c.Assert(stopExposeCalled, Equals, true)
+}
+
+func (s *TestSuite) TestPrepareFromSyncOpenFileFailureStopsInitiatorAndUnexposes(c *C) {
+	c.Log("Testing prepareFromSync stops initiator and unexposes source snapshot when device open fails")
+
+	origOpenFile := openFile
+	origNewNVMeTCPInitiator := newNVMeTCPInitiator
+	origBackingImageGetServiceClient := backingImageGetServiceClient
+	origBackingImageDiscoverAndConnectNVMeTarget := backingImageDiscoverAndConnectNVMeTarget
+	defer func() {
+		openFile = origOpenFile
+		newNVMeTCPInitiator = origNewNVMeTCPInitiator
+		backingImageGetServiceClient = origBackingImageGetServiceClient
+		backingImageDiscoverAndConnectNVMeTarget = origBackingImageDiscoverAndConnectNVMeTarget
+	}()
+
+	fakeInitiator := &fakeNVMeInitiator{endpoint: "/dev/fake-bi-sync"}
+	fakeServiceClient := &fakeBackingImageServiceClient{exposedAddress: "10.0.0.1:1000"}
+
+	openFile = func(string, int, os.FileMode) (*os.File, error) {
+		return nil, fmt.Errorf("open failed")
+	}
+	newNVMeTCPInitiator = func(string, *initiator.NVMeTCPInfo) (nvmeInitiator, error) {
+		return fakeInitiator, nil
+	}
+	backingImageGetServiceClient = func(string) (backingImageServiceClient, error) {
+		return fakeServiceClient, nil
+	}
+	backingImageDiscoverAndConnectNVMeTarget = func(string, int32, int, time.Duration) (string, string, error) {
+		return "", "", nil
+	}
+
+	bi := &BackingImage{
+		ctx:  context.Background(),
+		Name: "bi-a",
+		log:  safelog.NewSafeLogger(logrus.New()),
+	}
+
+	err := bi.prepareFromSync(nil, "remote-address", "src-lvs-uuid")
+	c.Assert(err, NotNil)
+	c.Assert(fakeServiceClient.exposeCalled, Equals, true)
+	c.Assert(fakeServiceClient.unexposeCalled, Equals, true)
+	c.Assert(fakeServiceClient.closeCalled, Equals, true)
+	c.Assert(fakeInitiator.startCalled, Equals, true)
+	c.Assert(fakeInitiator.stopCalled, Equals, true)
+}

--- a/pkg/spdk/resource_cleanup_test.go
+++ b/pkg/spdk/resource_cleanup_test.go
@@ -6,18 +6,19 @@ import (
 	"os"
 	"time"
 
-	commonbitmap "github.com/longhorn/go-common-libs/bitmap"
-	commonns "github.com/longhorn/go-common-libs/ns"
 	"github.com/sirupsen/logrus"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/longhorn/go-spdk-helper/pkg/initiator"
+
+	commonbitmap "github.com/longhorn/go-common-libs/bitmap"
+	commonns "github.com/longhorn/go-common-libs/ns"
 	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
 	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
 	helpertypes "github.com/longhorn/go-spdk-helper/pkg/types"
 
 	safelog "github.com/longhorn/longhorn-spdk-engine/pkg/log"
-
-	. "gopkg.in/check.v1"
 )
 
 type fakeNVMeInitiator struct {

--- a/pkg/spdk/restore.go
+++ b/pkg/spdk/restore.go
@@ -44,7 +44,7 @@ type Restore struct {
 	executor       *commonns.Executor
 	subsystemNQN   string
 	controllerName string
-	initiator      *initiator.Initiator
+	initiator      nvmeInitiator
 
 	stopOnce sync.Once
 	stopChan chan struct{}
@@ -117,8 +117,38 @@ func (r *Restore) DeepCopy() *Restore {
 	}
 }
 
-func (r *Restore) OpenVolumeDev(volDevName string) (*os.File, string, error) {
+func (r *Restore) OpenVolumeDev(volDevName string) (fh *os.File, endpoint string, err error) {
 	lvolName := r.replica.Name
+	cleanupExpose := false
+	defer func() {
+		if err == nil {
+			return
+		}
+
+		if fh != nil {
+			if errClose := fh.Close(); errClose != nil {
+				r.log.WithError(errClose).Warnf("Failed to close NVMe device %v during restore open cleanup", fh.Name())
+			}
+			fh = nil
+		}
+
+		if r.initiator != nil {
+			if _, stopErr := r.initiator.Stop(nil, true, true, false); stopErr != nil {
+				r.log.WithError(stopErr).Warnf("Failed to stop NVMe initiator for lvol bdev %v during restore open cleanup", lvolName)
+			}
+			r.initiator = nil
+		}
+
+		if cleanupExpose {
+			if stopErr := restoreStopExposeBdev(r.spdkClient, helpertypes.GetNQN(lvolName)); stopErr != nil {
+				r.log.WithError(stopErr).Warnf("Failed to unexpose lvol bdev %v during restore open cleanup", lvolName)
+			} else {
+				r.replica.IsExposed = false
+			}
+		}
+
+		endpoint = ""
+	}()
 
 	r.log.Info("Unexposing lvol bdev before restoration")
 	if r.replica.IsExposed {
@@ -130,11 +160,12 @@ func (r *Restore) OpenVolumeDev(volDevName string) (*os.File, string, error) {
 	}
 
 	r.log.Info("Exposing snapshot lvol bdev for restore")
-	subsystemNQN, controllerName, err := exposeSnapshotLvolBdev(r.spdkClient, r.replica.LvsName, lvolName, r.ip, r.port, r.executor)
+	subsystemNQN, controllerName, err := restoreExposeSnapshotLvolBdev(r.spdkClient, r.replica.LvsName, lvolName, r.ip, r.port, r.executor)
 	if err != nil {
 		r.log.WithError(err).Errorf("Failed to expose lvol bdev")
 		return nil, "", err
 	}
+	cleanupExpose = true
 	r.subsystemNQN = subsystemNQN
 	r.controllerName = controllerName
 	r.replica.IsExposed = true
@@ -144,7 +175,7 @@ func (r *Restore) OpenVolumeDev(volDevName string) (*os.File, string, error) {
 	nvmeTCPInfo := &initiator.NVMeTCPInfo{
 		SubsystemNQN: helpertypes.GetNQN(lvolName),
 	}
-	i, err := initiator.NewInitiator(lvolName, initiator.HostProc, nvmeTCPInfo, nil)
+	i, err := newNVMeTCPInitiator(lvolName, nvmeTCPInfo)
 	if err != nil {
 		return nil, "", errors.Wrapf(err, "failed to create NVMe initiator for lvol bdev %v", lvolName)
 	}
@@ -153,36 +184,55 @@ func (r *Restore) OpenVolumeDev(volDevName string) (*os.File, string, error) {
 	}
 	r.initiator = i
 
-	r.log.Infof("Opening NVMe device %v", r.initiator.Endpoint)
-	fh, err := os.OpenFile(r.initiator.Endpoint, os.O_RDONLY, 0666)
+	r.log.Infof("Opening NVMe device %v", r.initiator.Endpoint())
+	fh, err = openFile(r.initiator.Endpoint(), os.O_RDONLY, 0666)
 	if err != nil {
-		return nil, "", errors.Wrapf(err, "failed to open NVMe device %v for lvol bdev %v", r.initiator.Endpoint, lvolName)
+		return nil, "", errors.Wrapf(err, "failed to open NVMe device %v for lvol bdev %v", r.initiator.Endpoint(), lvolName)
 	}
 
-	return fh, r.initiator.Endpoint, err
+	return fh, r.initiator.Endpoint(), nil
 }
 
 func (r *Restore) CloseVolumeDev(volDev *os.File) error {
-	r.log.Infof("Closing NVMe device %v", r.initiator.Endpoint)
-	if err := volDev.Close(); err != nil {
-		return errors.Wrapf(err, "failed to close NVMe device %v", r.initiator.Endpoint)
+	var errs []error
+	endpoint := getDeviceEndpoint(r.initiator, volDev)
+
+	if volDev != nil {
+		if endpoint != "" {
+			r.log.Infof("Closing NVMe device %v", endpoint)
+		} else {
+			r.log.Info("Closing NVMe device")
+		}
+		if err := volDev.Close(); err != nil {
+			if endpoint != "" {
+				errs = append(errs, errors.Wrapf(err, "failed to close NVMe device %v", endpoint))
+			} else {
+				errs = append(errs, errors.Wrap(err, "failed to close NVMe device"))
+			}
+		}
 	}
 
-	r.log.Info("Stopping NVMe initiator")
-	if _, err := r.initiator.Stop(nil, true, true, false); err != nil {
-		return errors.Wrapf(err, "failed to stop NVMe initiator")
+	if r.initiator != nil {
+		r.log.Info("Stopping NVMe initiator")
+		if _, err := r.initiator.Stop(nil, true, true, false); err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed to stop NVMe initiator"))
+		}
 	}
 
-	if !r.replica.IsExposed {
+	if r.replica != nil && r.replica.IsExposed {
 		r.log.Info("Unexposing lvol bdev")
 		lvolName := r.replica.Name
-		err := r.spdkClient.StopExposeBdev(helpertypes.GetNQN(lvolName))
+		err := restoreStopExposeBdev(r.spdkClient, helpertypes.GetNQN(lvolName))
 		if err != nil {
-			return errors.Wrapf(err, "failed to unexpose lvol bdev %v", lvolName)
+			errs = append(errs, errors.Wrapf(err, "failed to unexpose lvol bdev %v", lvolName))
+		} else {
+			r.replica.IsExposed = false
 		}
-		r.replica.IsExposed = false
 	}
 
+	if len(errs) > 0 {
+		return errors.Errorf("CloseVolumeDev encountered %d error(s): %v", len(errs), errs)
+	}
 	return nil
 }
 

--- a/pkg/spdk/server_replica.go
+++ b/pkg/spdk/server_replica.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
@@ -15,6 +17,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/longhorn/backupstore"
+	btypes "github.com/longhorn/backupstore/types"
 	"github.com/longhorn/types/pkg/generated/spdkrpc"
 
 	butil "github.com/longhorn/backupstore/util"
@@ -23,6 +26,11 @@ import (
 	"github.com/longhorn/longhorn-spdk-engine/pkg/types"
 	"github.com/longhorn/longhorn-spdk-engine/pkg/util"
 )
+
+var retainBackupStateCounts = map[btypes.ProgressState]int{
+	btypes.ProgressStateComplete: 100,
+	btypes.ProgressStateError:    100,
+}
 
 func (s *Server) ReplicaCreate(ctx context.Context, req *spdkrpc.ReplicaCreateRequest) (ret *spdkrpc.Replica, err error) {
 	if req.Name == "" {
@@ -752,7 +760,12 @@ func (s *Server) ReplicaBackupCreate(ctx context.Context, req *spdkrpc.BackupCre
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find replica %v for volume %v backup creation", req.ReplicaName, req.VolumeName)
 	}
 
-	backup, err := NewBackup(s.spdkClient, backupName, req.VolumeName, req.SnapshotName, replica, s.portAllocator)
+	var backup *Backup
+	backup, err = NewBackup(s.spdkClient, backupName, req.VolumeName, req.SnapshotName, replica, s.portAllocator, func() {
+		s.Lock()
+		defer s.Unlock()
+		s.onBackupTerminalLocked()
+	})
 	if err != nil {
 		err = errors.Wrapf(err, "failed to create backup instance %v for volume %v", backupName, req.VolumeName)
 		return nil, grpcstatus.Errorf(grpccodes.Internal, "%v", err)
@@ -781,9 +794,12 @@ func (s *Server) ReplicaBackupCreate(ctx context.Context, req *spdkrpc.BackupCre
 		Labels:   labelMap,
 	}
 
-	s.backupMap[backupName] = backup
+	s.trackBackupLocked(backupName, backup)
 	if err := backup.BackupCreate(config); err != nil {
-		delete(s.backupMap, backupName)
+		s.removeBackupLocked(backupName)
+		backup.Lock()
+		backup.releaseHeavyResourcesLocked()
+		backup.Unlock()
 		err = errors.Wrapf(err, "failed to create backup %v for volume %v", backupName, req.VolumeName)
 		return nil, grpcstatus.Errorf(grpccodes.Internal, "%v", err)
 	}
@@ -804,8 +820,8 @@ func (s *Server) ReplicaBackupStatus(ctx context.Context, req *spdkrpc.BackupSta
 	}
 
 	replicaAddress := ""
-	if backup.replica != nil {
-		replicaAddress = fmt.Sprintf("tcp://%s", backup.replica.GetAddress())
+	if backup.replicaAddress != "" {
+		replicaAddress = fmt.Sprintf("tcp://%s", backup.replicaAddress)
 	}
 
 	return &spdkrpc.BackupStatusResponse{
@@ -816,6 +832,54 @@ func (s *Server) ReplicaBackupStatus(ctx context.Context, req *spdkrpc.BackupSta
 		State:          string(backup.State),
 		ReplicaAddress: replicaAddress,
 	}, nil
+}
+
+func (s *Server) trackBackupLocked(backupName string, backup *Backup) {
+	s.backupMap[backupName] = backup
+	s.pruneRetainedBackupsLocked()
+}
+
+// onBackupTerminalLocked is called (via the onTerminal goroutine) when a backup
+// first reaches a terminal state. It triggers pruning so that excess terminal
+// entries are evicted based on their terminalAt timestamp.
+func (s *Server) onBackupTerminalLocked() {
+	s.pruneRetainedBackupsLocked()
+}
+
+func (s *Server) removeBackupLocked(backupName string) {
+	delete(s.backupMap, backupName)
+}
+
+func (s *Server) pruneRetainedBackupsLocked() {
+	type terminalEntry struct {
+		name       string
+		terminalAt time.Time
+	}
+	for state, limit := range retainBackupStateCounts {
+		var entries []terminalEntry
+		for name, backup := range s.backupMap {
+			backup.Lock()
+			if backup.State == state && backup.terminalSeen {
+				entries = append(entries, terminalEntry{name, backup.terminalAt})
+			}
+			backup.Unlock()
+		}
+		if len(entries) <= limit {
+			continue
+		}
+		// Sort newest first (descending terminalAt); keep the first `limit`.
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].terminalAt.After(entries[j].terminalAt)
+		})
+		for _, e := range entries[limit:] {
+			if backup := s.backupMap[e.name]; backup != nil {
+				backup.Lock()
+				backup.releaseHeavyResourcesLocked()
+				backup.Unlock()
+			}
+			s.removeBackupLocked(e.name)
+		}
+	}
 }
 
 func (s *Server) ReplicaBackupRestore(ctx context.Context, req *spdkrpc.ReplicaBackupRestoreRequest) (ret *emptypb.Empty, err error) {

--- a/pkg/spdk/server_replica.go
+++ b/pkg/spdk/server_replica.go
@@ -796,10 +796,25 @@ func (s *Server) ReplicaBackupCreate(ctx context.Context, req *spdkrpc.BackupCre
 
 	s.trackBackupLocked(backupName, backup)
 	if err := backup.BackupCreate(config); err != nil {
-		s.removeBackupLocked(backupName)
 		backup.Lock()
 		backup.releaseHeavyResourcesLocked()
-		backup.Unlock()
+		if backup.hasActiveSnapshotResourcesLocked() {
+			// Resources (NVMe-oF target, initiator, or port) are still
+			// active after a partial rollback failure.  Keep the backup
+			// in the map so it remains discoverable for monitoring and
+			// future prune/retry, and mark it as a terminal error.
+			backup.State = btypes.ProgressStateError
+			backup.Error = err.Error()
+			if backup.terminalAt.IsZero() {
+				backup.terminalAt = time.Now()
+			}
+			backup.markTerminalHandledLocked()
+			backup.log.Warnf("Backup %v creation failed with resources still active; keeping in map for observability", backupName)
+			backup.Unlock()
+		} else {
+			backup.Unlock()
+			s.removeBackupLocked(backupName)
+		}
 		err = errors.Wrapf(err, "failed to create backup %v for volume %v", backupName, req.VolumeName)
 		return nil, grpcstatus.Errorf(grpccodes.Internal, "%v", err)
 	}
@@ -859,7 +874,7 @@ func (s *Server) pruneRetainedBackupsLocked() {
 		var entries []terminalEntry
 		for name, backup := range s.backupMap {
 			backup.Lock()
-			if backup.State == state && backup.terminalSeen {
+			if backup.State == state && backup.terminalSeen && !backup.hasActiveSnapshotResourcesLocked() {
 				entries = append(entries, terminalEntry{name, backup.terminalAt})
 			}
 			backup.Unlock()

--- a/pkg/spdk/server_replica.go
+++ b/pkg/spdk/server_replica.go
@@ -17,9 +17,9 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/longhorn/backupstore"
-	btypes "github.com/longhorn/backupstore/types"
 	"github.com/longhorn/types/pkg/generated/spdkrpc"
 
+	btypes "github.com/longhorn/backupstore/types"
 	butil "github.com/longhorn/backupstore/util"
 
 	"github.com/longhorn/longhorn-spdk-engine/pkg/api"


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/13114

#### What this PR does / why we need it:

Harden the backup and restore open paths so partial setup does not leave NVMe initiators or exposed bdevs behind.

#### Special notes for your reviewer:

#### Additional documentation or context
