### PR TITLE
fix(backup): harden backup failure handling

### DIFF
--- a/pkg/spdk/backup.go
+++ b/pkg/spdk/backup.go
@@ -23,6 +23,7 @@ import (
 	helpertypes "github.com/longhorn/go-spdk-helper/pkg/types"
 	helperutil "github.com/longhorn/go-spdk-helper/pkg/util"
 
+	"github.com/longhorn/longhorn-spdk-engine/pkg/types"
 	"github.com/longhorn/longhorn-spdk-engine/pkg/util"
 )
 
@@ -208,8 +209,20 @@ func (b *Backup) CompareSnapshot(snapshotName, compareSnapshotName, volumeName s
 	return b.constructMappings(blockSize), nil
 }
 
-// ReadSnapshot reads the data from the block device exposed by NVMe/TCP TCP
+// ReadSnapshot reads the data from the block device exposed by NVMe/TCP TCP.
+// It checks replica health before reading so that the backup fails naturally
+// through backupstore's error path when the replica is no longer running,
+// matching v1 behavior where killing the replica process stops the backup.
 func (b *Backup) ReadSnapshot(snapshotName, volumeName string, offset int64, data []byte) error {
+	b.replica.RLock()
+	replicaState := b.replica.State
+	replicaName := b.replica.Name
+	b.replica.RUnlock()
+
+	if replicaState != types.InstanceStateRunning {
+		return fmt.Errorf("replica %s is in %s state", replicaName, replicaState)
+	}
+
 	b.Lock()
 	defer b.Unlock()
 
@@ -249,17 +262,20 @@ func (b *Backup) UpdateBackupStatus(snapshotName, volumeName string, state strin
 	b.Lock()
 	defer b.Unlock()
 
+	if b.State == btypes.ProgressStateComplete || b.State == btypes.ProgressStateError {
+		b.log.Warnf("Backup of volume %v snapshot %v already completed or failed, skip the status update", b.VolumeName, b.SnapshotName)
+		return nil
+	}
+
 	b.State = btypes.ProgressState(state)
 	b.Progress = progress
 	b.BackupURL = url
 	b.Error = errString
 
-	if b.Progress == 100 {
+	if b.Error != "" {
+		b.State = btypes.ProgressStateError
+	} else if b.Progress == 100 {
 		b.State = btypes.ProgressStateComplete
-	} else {
-		if b.Error != "" {
-			b.State = btypes.ProgressStateError
-		}
 	}
 
 	return nil

--- a/pkg/spdk/backup_test.go
+++ b/pkg/spdk/backup_test.go
@@ -1,0 +1,37 @@
+package spdk
+
+import (
+	"github.com/sirupsen/logrus"
+
+	btypes "github.com/longhorn/backupstore/types"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *TestSuite) TestUpdateBackupStatusPrefersErrorOverComplete(c *C) {
+	b := &Backup{log: logrus.New()}
+
+	err := b.UpdateBackupStatus("snap-1", "vol-1", string(btypes.ProgressStateInProgress), 100, "backup-url", "upload failed")
+
+	c.Assert(err, IsNil)
+	c.Assert(b.State, Equals, btypes.ProgressStateError)
+	c.Assert(b.Progress, Equals, 100)
+	c.Assert(b.Error, Equals, "upload failed")
+	c.Assert(b.BackupURL, Equals, "backup-url")
+}
+
+func (s *TestSuite) TestUpdateBackupStatusKeepsErrorAsFinalState(c *C) {
+	b := &Backup{log: logrus.New()}
+
+	err := b.UpdateBackupStatus("snap-1", "vol-1", string(btypes.ProgressStateInProgress), 42, "", "upload failed")
+	c.Assert(err, IsNil)
+	c.Assert(b.State, Equals, btypes.ProgressStateError)
+
+	err = b.UpdateBackupStatus("snap-1", "vol-1", string(btypes.ProgressStateInProgress), 100, "backup-url", "")
+
+	c.Assert(err, IsNil)
+	c.Assert(b.State, Equals, btypes.ProgressStateError)
+	c.Assert(b.Progress, Equals, 42)
+	c.Assert(b.Error, Equals, "upload failed")
+	c.Assert(b.BackupURL, Equals, "")
+}


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#12842

#### What this PR does / why we need it:

Check replica state before reading snapshot data so backups fail through the normal error path when the replica is no longer running.

Also make UpdateBackupStatus preserve error as the final state even when progress reaches 100, and add tests to cover both error-first and error-after-completion cases.


#### Special notes for your reviewer:

#### Additional documentation or context
