### PR TITLE
fix(spdk): make engine frontend recovery async to prevent pod crash loop

### DIFF
--- a/pkg/spdk/enginefrontend.go
+++ b/pkg/spdk/enginefrontend.go
@@ -15,18 +15,18 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.uber.org/multierr"
 
+	"github.com/longhorn/go-spdk-helper/pkg/initiator"
+	"github.com/longhorn/types/pkg/generated/spdkrpc"
+
+	commonbitmap "github.com/longhorn/go-common-libs/bitmap"
+	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
+	helpertypes "github.com/longhorn/go-spdk-helper/pkg/types"
+
 	"github.com/longhorn/longhorn-spdk-engine/pkg/client"
 	"github.com/longhorn/longhorn-spdk-engine/pkg/types"
 	"github.com/longhorn/longhorn-spdk-engine/pkg/util"
 
-	commonbitmap "github.com/longhorn/go-common-libs/bitmap"
 	safelog "github.com/longhorn/longhorn-spdk-engine/pkg/log"
-
-	"github.com/longhorn/go-spdk-helper/pkg/initiator"
-	"github.com/longhorn/types/pkg/generated/spdkrpc"
-
-	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
-	helpertypes "github.com/longhorn/go-spdk-helper/pkg/types"
 )
 
 type EngineFrontend struct {
@@ -83,6 +83,8 @@ type EngineFrontend struct {
 	connectNvmeTCPPathFn func(transportAddress, transportServiceID string) error
 	// Test hook for native multipath path reconnect during recovery.
 	reconnectNvmeTCPPathFn func(transportAddress, transportServiceID string) error
+	// Test hook for target TCP reachability check during recovery.
+	checkTargetReachableFn func(address string) error
 	// Test hook for initiator NVMe device info loading.
 	loadInitiatorNVMeDeviceInfoFn func(transportAddress, transportServiceID, subsystemNQN string) error
 	// Test hook for initiator endpoint loading.
@@ -126,6 +128,13 @@ const (
 
 	anaSyncMaxAttempts   = 5
 	anaSyncRetryInterval = 200 * time.Millisecond
+
+	// recoveryTargetReachabilityTimeout is the timeout for a TCP dial to
+	// verify the NVMe-TCP target is reachable before attempting expensive
+	// reconnect retries during engine frontend recovery. This only applies
+	// to the recovery path — normal creation and switchover paths use the
+	// full retry loop in the initiator package.
+	recoveryTargetReachabilityTimeout = 5 * time.Second
 )
 
 type NvmeTCPPath struct {
@@ -2184,6 +2193,21 @@ func (ef *EngineFrontend) loadInitiatorEndpoint(dmDeviceIsBusy bool) error {
 	return ef.initiator.LoadEndpointForNvmeTcpFrontend(dmDeviceIsBusy)
 }
 
+func (ef *EngineFrontend) checkTargetReachable(address string) error {
+	if ef.checkTargetReachableFn != nil {
+		return ef.checkTargetReachableFn(address)
+	}
+	conn, err := net.DialTimeout("tcp", address, recoveryTargetReachabilityTimeout)
+	if err != nil {
+		return err
+	}
+	errClose := conn.Close()
+	if errClose != nil {
+		ef.log.WithError(errClose).Warnf("Failed to close connection to target address %s", address)
+	}
+	return nil
+}
+
 func (ef *EngineFrontend) getInitiatorEndpoint() string {
 	if ef.getInitiatorEndpointFn != nil {
 		return ef.getInitiatorEndpointFn()
@@ -2516,6 +2540,16 @@ func (ef *EngineFrontend) validateAndUpdateNvmeTcpFrontend() (err error) {
 	return nil
 }
 
+// isRecoveryCancelled checks whether a concurrent operation (e.g.
+// EngineFrontendCreate) has changed this ef's state away from Pending,
+// meaning the recovery goroutine should abort before performing further
+// host-level NVMe/dm operations.
+func (ef *EngineFrontend) isRecoveryCancelled() bool {
+	ef.RLock()
+	defer ef.RUnlock()
+	return ef.State != types.InstanceStatePending
+}
+
 // RecoverFromHost attempts to recover the engine frontend's initiator state by
 // detecting existing NVMe controllers and dm-devices on the host. This is called
 // during server startup for engine frontends that were persisted before restart.
@@ -2542,6 +2576,16 @@ func (ef *EngineFrontend) RecoverFromHost(spdkClient *spdkclient.Client) error {
 			// Device not found on host — record already removed, nothing to reconcile.
 			return
 		}
+
+		// If the state has been changed from Pending by a concurrent operation
+		// (e.g. Delete was called during recovery), do not overwrite it.
+		// This prevents a race where recovery's deferred update would revert
+		// a Terminating/Stopped state set by Delete back to Error/Running.
+		if ef.State != types.InstanceStatePending {
+			ef.log.Infof("Skipping recovery state update for engine frontend %s: state already changed to %s by concurrent operation", ef.Name, ef.State)
+			return
+		}
+
 		if recoverErr != nil {
 			ef.log.WithError(recoverErr).Errorf("Failed to recover engine frontend %s from host", ef.Name)
 			ef.State = types.InstanceStateError
@@ -2613,6 +2657,20 @@ func (ef *EngineFrontend) RecoverFromHost(spdkClient *spdkclient.Client) error {
 			reconnected := false
 			if strings.Contains(loadErr.Error(), helpertypes.ErrorMessageCannotFindValidNvmeDevice) {
 				if ef.NvmeTcpFrontend.TargetIP != "" && ef.NvmeTcpFrontend.TargetPort != 0 {
+					targetAddr := net.JoinHostPort(ef.NvmeTcpFrontend.TargetIP, strconv.Itoa(int(ef.NvmeTcpFrontend.TargetPort)))
+					if dialErr := ef.checkTargetReachable(targetAddr); dialErr != nil {
+						ef.log.WithError(dialErr).Warnf("NVMe/TCP target %s is not reachable during recovery of engine frontend %s, skipping reconnect retries", targetAddr, ef.Name)
+						recoverErr = errors.Wrapf(dialErr, "NVMe/TCP target %s is not reachable during recovery", targetAddr)
+						return recoverErr
+					}
+					// Check cancellation before the expensive host-mutating reconnect.
+					// A concurrent EngineFrontendCreate may have evicted us while
+					// the TCP pre-check was in progress.
+					if ef.isRecoveryCancelled() {
+						recoverErr = ErrRecoveryCancelled
+						return recoverErr
+					}
+
 					ef.log.WithError(loadErr).Warnf("NVMe device not found on host during recovery of engine frontend %s, reconnecting persisted multipath target", ef.Name)
 					if reconnectErr := ef.reconnectNvmeTCPPath(ef.NvmeTcpFrontend.TargetIP, ef.NvmeTcpFrontend.TargetPort); reconnectErr != nil {
 						recoverErr = errors.Wrapf(reconnectErr, "failed to reconnect NVMe/TCP path during recovery of engine frontend %s", ef.Name)
@@ -2632,6 +2690,14 @@ func (ef *EngineFrontend) RecoverFromHost(spdkClient *spdkclient.Client) error {
 				recoverErr = errors.Wrapf(loadErr, "failed to load NVMe device info during recovery of engine frontend %s", ef.Name)
 				return recoverErr
 			}
+		}
+
+		// Check cancellation before loading the dm-device endpoint.
+		// A concurrent EngineFrontendCreate may have evicted us during
+		// the preceding reconnect or sysfs scan.
+		if ef.isRecoveryCancelled() {
+			recoverErr = ErrRecoveryCancelled
+			return recoverErr
 		}
 
 		// Try to load the existing dm-device endpoint.

--- a/pkg/spdk/enginefrontend.go
+++ b/pkg/spdk/enginefrontend.go
@@ -155,6 +155,22 @@ type UblkFrontend struct {
 	UblkID int32
 }
 
+func (ef *EngineFrontend) setMetadataDirLocked(metadataDir string) {
+	ef.metadataDir = metadataDir
+}
+
+func (ef *EngineFrontend) setMetadataDir(metadataDir string) {
+	ef.Lock()
+	defer ef.Unlock()
+	ef.setMetadataDirLocked(metadataDir)
+}
+
+func (ef *EngineFrontend) getMetadataDir() string {
+	ef.RLock()
+	defer ef.RUnlock()
+	return ef.metadataDir
+}
+
 func getUblkQueueDepth(ublkQueueDepth int32) int32 {
 	if ublkQueueDepth == 0 {
 		return types.DefaultUblkQueueDepth
@@ -2620,6 +2636,17 @@ func (ef *EngineFrontend) RecoverFromHost(spdkClient *spdkclient.Client) error {
 		return nil
 
 	case types.FrontendSPDKTCPBlockdev:
+		// Early cancellation check before creating the NVMe-TCP initiator.
+		// If a concurrent EngineFrontendCreate already completed for this
+		// volume (evicted us and connected its own NVMe controller), we must
+		// not proceed — creating an initiator and then calling Delete/Stop
+		// would disconnect the NEW ef's controller via DisconnectTarget
+		// (which disconnects ALL controllers for the subsystem NQN).
+		if ef.isRecoveryCancelled() {
+			recoverErr = ErrRecoveryCancelled
+			return recoverErr
+		}
+
 		// Recover the NVMe-oF initiator (blockdev frontend with dm-device).
 		i, nqn, nguid, err := ef.newNvmeTcpInitiator()
 		if err != nil {
@@ -2679,7 +2706,7 @@ func (ef *EngineFrontend) RecoverFromHost(spdkClient *spdkclient.Client) error {
 					reconnected = true
 				} else {
 					ef.log.WithError(loadErr).Warnf("NVMe device not found on host during recovery of engine frontend %s, removing persisted record", ef.Name)
-					if removeErr := removeEngineFrontendRecord(ef.metadataDir, ef.VolumeName); removeErr != nil {
+					if removeErr := removeEngineFrontendRecord(ef.getMetadataDir(), ef.VolumeName); removeErr != nil {
 						ef.log.WithError(removeErr).Warn("Failed to remove engine frontend record")
 					}
 					deviceNotFound = true

--- a/pkg/spdk/enginefrontend_persist_test.go
+++ b/pkg/spdk/enginefrontend_persist_test.go
@@ -421,6 +421,7 @@ func (s *TestSuite) TestRecoverFromHostBlockdevReconnectsPersistedTarget(c *C) {
 	ef.NvmeTcpFrontend.TargetIP = "10.0.0.8"
 	ef.NvmeTcpFrontend.TargetPort = 4420
 	ef.getInitiatorEndpointFn = func() string { return "/dev/longhorn/vol-r" }
+	ef.checkTargetReachableFn = func(address string) error { return nil }
 
 	loadCalls := 0
 	ef.loadInitiatorNVMeDeviceInfoFn = func(transportAddress, transportServiceID, subsystemNQN string) error {
@@ -470,6 +471,59 @@ func (s *TestSuite) TestRecoverFromHostBlockdevReconnectsPersistedTarget(c *C) {
 	c.Assert(got.Endpoint, Equals, "/dev/longhorn/vol-r")
 	c.Assert(got.TargetIp, Equals, "10.0.0.8")
 	c.Assert(got.TargetPort, Equals, int32(4420))
+
+	select {
+	case <-updateCh:
+	case <-time.After(time.Second):
+		c.Fatal("expected update on UpdateCh")
+	}
+}
+
+func (s *TestSuite) TestRecoverFromHostBlockdevSkipsReconnectWhenTargetUnreachable(c *C) {
+	updateCh := make(chan interface{}, 1)
+
+	ef := NewEngineFrontend("ef-block-recover", "engine-r", "vol-r",
+		lhtypes.FrontendSPDKTCPBlockdev, 1048576, 0, 0, updateCh)
+	ef.NvmeTcpFrontend.TargetIP = "10.0.0.8"
+	ef.NvmeTcpFrontend.TargetPort = 4420
+
+	loadCalls := 0
+	ef.loadInitiatorNVMeDeviceInfoFn = func(transportAddress, transportServiceID, subsystemNQN string) error {
+		loadCalls++
+		c.Assert(subsystemNQN, Equals, getStableVolumeNQN("vol-r"))
+		if loadCalls == 1 {
+			c.Assert(transportAddress, Equals, "10.0.0.8")
+			c.Assert(transportServiceID, Equals, "4420")
+			return fmt.Errorf("%s", helpertypes.ErrorMessageCannotFindValidNvmeDevice)
+		}
+		c.Assert(transportAddress, Equals, "")
+		c.Assert(transportServiceID, Equals, "")
+		return fmt.Errorf("%s", helpertypes.ErrorMessageCannotFindValidNvmeDevice)
+	}
+
+	reconnectCalled := false
+	ef.reconnectNvmeTCPPathFn = func(transportAddress, transportServiceID string) error {
+		reconnectCalled = true
+		return nil
+	}
+	ef.checkTargetReachableFn = func(address string) error {
+		c.Assert(address, Equals, "10.0.0.8:4420")
+		return fmt.Errorf("dial tcp %s: i/o timeout", address)
+	}
+	ef.loadInitiatorEndpointFn = func(dmDeviceIsBusy bool) error {
+		c.Fatal("loadInitiatorEndpoint should not run when reachability check fails")
+		return nil
+	}
+
+	err := ef.RecoverFromHost(nil)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Matches, ".*not reachable during recovery.*")
+	c.Assert(reconnectCalled, Equals, false)
+	c.Assert(loadCalls, Equals, 2)
+
+	got := ef.Get()
+	c.Assert(got.State, Equals, string(lhtypes.InstanceStateError))
+	c.Assert(got.ErrorMsg, Matches, ".*not reachable during recovery.*")
 
 	select {
 	case <-updateCh:

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -1132,6 +1132,11 @@ func (s *Server) recoverEngineFrontends(ctx context.Context) {
 
 			if current != ef {
 				logrus.Warnf("Engine frontend %s was superseded during recovery, cleaning up recovered resources", record.Name)
+				// The eviction path in EngineFrontendCreate already decided
+				// whether metadataDir should be kept (pre-create eviction,
+				// where no new record exists yet) or cleared (post-create
+				// eviction with successful Create, where a new record was
+				// written). Respect that decision — do not override here.
 				if deleteErr := ef.Delete(spdkClient); deleteErr != nil {
 					logrus.WithError(deleteErr).Warnf("Failed to clean up superseded engine frontend %s", record.Name)
 				}

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -66,6 +66,19 @@ type Server struct {
 	currentBdevIostat *spdktypes.BdevIostatResponse
 	bdevMetricMap     map[string]*spdkrpc.Metrics
 
+	// volumeHostLocksMu protects the volumeHostLocks map itself.
+	volumeHostLocksMu sync.Mutex
+	// volumeHostLocks serializes host-level NVMe/dm operations for the same
+	// volume. Recovery and all frontend lifecycle RPCs that mutate host
+	// NVMe controllers or dm devices (create, delete, suspend, resume,
+	// expand, switchover) acquire the per-volume lock so that these
+	// operations cannot overlap on one volume.
+	//
+	// Entries are reference-counted and removed when the last holder
+	// releases, so the map is bounded by the number of concurrently
+	// active volumes rather than growing monotonically.
+	volumeHostLocks map[string]*volumeHostLockEntry
+
 	// metadataDir is the base path for persisting engine frontend records
 	// (e.g. /var/lib/longhorn). If empty, persistence is disabled.
 	metadataDir string
@@ -122,6 +135,8 @@ func NewServer(ctx context.Context, portStart, portEnd int32) (*Server, error) {
 		broadcastChs: broadcastChs,
 		updateChs:    updateChs,
 
+		volumeHostLocks: map[string]*volumeHostLockEntry{},
+
 		metadataDir: types.MetadataDir,
 	}
 	s.hotplugActive.Store(true)
@@ -143,7 +158,11 @@ func NewServer(ctx context.Context, portStart, portEnd int32) (*Server, error) {
 	// RecoverFromHost do not block on the unbuffered channel.
 	go s.broadcasting()
 
-	s.recoverEngineFrontends()
+	// Run engine frontend recovery asynchronously so that gRPC servers can
+	// start listening immediately. This prevents the liveness probe from
+	// killing the pod when recovery takes longer than the probe threshold
+	// (e.g. when persisted targets are unreachable).
+	go s.recoverEngineFrontends(ctx)
 
 	// TODO: There is no need to maintain the replica map in cache when we can use one SPDK JSON API call to fetch the Lvol tree/chain info
 	go s.monitoring()
@@ -814,6 +833,46 @@ func setNvmeHotPlug(spdkClient *spdkclient.Client, enable bool) (success bool) {
 	return true
 }
 
+// volumeHostLockEntry is a reference-counted per-volume mutex.
+type volumeHostLockEntry struct {
+	mu       sync.Mutex
+	refCount int32
+}
+
+// acquireVolumeHostLock atomically looks up (or creates) the per-volume lock,
+// increments its reference count, and acquires the mutex. The returned
+// function releases the mutex and decrements the reference count; when the
+// count reaches zero the entry is removed from the map, bounding memory to
+// the number of concurrently active volumes.
+func (s *Server) acquireVolumeHostLock(volumeName string) func() {
+	s.volumeHostLocksMu.Lock()
+	if s.volumeHostLocks == nil {
+		s.volumeHostLocks = map[string]*volumeHostLockEntry{}
+	}
+	entry, ok := s.volumeHostLocks[volumeName]
+	if !ok {
+		entry = &volumeHostLockEntry{}
+		s.volumeHostLocks[volumeName] = entry
+	}
+	atomic.AddInt32(&entry.refCount, 1)
+	s.volumeHostLocksMu.Unlock()
+
+	entry.mu.Lock()
+
+	return func() {
+		entry.mu.Unlock()
+		if atomic.AddInt32(&entry.refCount, -1) == 0 {
+			s.volumeHostLocksMu.Lock()
+			// Re-check under map lock: another goroutine may have
+			// incremented refCount between our Add and this Lock.
+			if atomic.LoadInt32(&entry.refCount) == 0 {
+				delete(s.volumeHostLocks, volumeName)
+			}
+			s.volumeHostLocksMu.Unlock()
+		}
+	}
+}
+
 // engineFrontendByVolumeName returns the first engine frontend that matches
 // the given volume name, or nil if none exists. Caller must hold s.RLock or
 // s.Lock.
@@ -913,7 +972,7 @@ func (s *Server) GetReplicaStruct(name string) *Replica {
 // recoverEngineFrontends loads persisted engine frontend records from disk
 // and attempts to recover them by detecting existing NVMe initiators on the host.
 // This is called during server startup to restore state after instance-manager restart.
-func (s *Server) recoverEngineFrontends() {
+func (s *Server) recoverEngineFrontends(ctx context.Context) {
 	if s.metadataDir == "" {
 		return
 	}
@@ -930,11 +989,28 @@ func (s *Server) recoverEngineFrontends() {
 
 	logrus.Infof("Recovering %d engine frontend(s) from persisted records", len(records))
 
+	// recoveryEfs keeps our own references to efs inserted during the
+	// insertion loop. The recovery loop uses these instead of reading
+	// from engineFrontendMap, which avoids accidentally operating on a
+	// NEW ef registered by a concurrent EngineFrontendCreate.
+	recoveryEfs := make(map[string]*EngineFrontend, len(records))
+
 	s.Lock()
-	spdkClient := s.spdkClient
 	for _, record := range records {
 		if _, exists := s.engineFrontendMap[record.Name]; exists {
 			logrus.Infof("Engine frontend %s already exists in map, skipping recovery", record.Name)
+			continue
+		}
+
+		// Check volume uniqueness — a concurrent frontend lifecycle RPC may
+		// already have registered an in-memory frontend for this volume while
+		// we were loading records from disk. Skip recovery so we do not race
+		// that in-memory owner on the host. The on-disk record may already
+		// belong to the in-memory frontend or may still be stale from the old
+		// one; reconciliation stays with the live frontend instance.
+		if existing := s.engineFrontendByVolumeName(record.VolumeName); existing != nil {
+			logrus.Warnf("Engine frontend %s already exists for volume %s, skipping recovery of %s",
+				existing.Name, record.VolumeName, record.Name)
 			continue
 		}
 
@@ -978,6 +1054,7 @@ func (s *Server) recoverEngineFrontends() {
 		}
 
 		s.engineFrontendMap[record.Name] = ef
+		recoveryEfs[record.Name] = ef
 
 		logrus.Infof("Recovered engine frontend %s for volume %s from persisted record", record.Name, record.VolumeName)
 	}
@@ -986,20 +1063,47 @@ func (s *Server) recoverEngineFrontends() {
 	// Attempt to recover each frontend's initiator state from the host.
 	// This is done outside the server lock to avoid holding it during potentially
 	// slow NVMe device discovery operations.
+	// Use recoveryEfs (our own references) rather than reading from engineFrontendMap
+	// to avoid accidentally calling RecoverFromHost/Delete on a NEW ef that a
+	// concurrent EngineFrontendCreate registered under the same name.
 	for _, record := range records {
-		s.RLock()
-		ef := s.engineFrontendMap[record.Name]
-		s.RUnlock()
+		select {
+		case <-ctx.Done():
+			logrus.Info("Engine frontend recovery cancelled by context")
+			return
+		default:
+		}
 
+		ef := recoveryEfs[record.Name]
 		if ef == nil {
 			continue
 		}
 
-		if err := ef.RecoverFromHost(spdkClient); err != nil {
-			if errors.Is(err, ErrRecoverDeviceNotFound) {
+		// Hold the per-volume host lock for the entire recovery lifecycle
+		// (RecoverFromHost + cleanup/Delete) so that a concurrent
+		// EngineFrontendCreate for the same volume cannot start its own
+		// host NVMe/dm operations until both recovery AND cleanup finish.
+		// Releasing the lock before Delete would allow Create to race with
+		// the old ef's initiator.Stop(), which could disconnect an NVMe
+		// controller that the new ef's Create() just connected (they share
+		// the same subsystem NQN derived from the volume name).
+		unlockVolumeHost := s.acquireVolumeHostLock(ef.VolumeName)
+
+		// Read spdkClient fresh each iteration — clientReconnect() can
+		// replace s.spdkClient and close the old one concurrently.
+		s.RLock()
+		spdkClient := s.spdkClient
+		s.RUnlock()
+
+		recoverErr := ef.RecoverFromHost(spdkClient)
+
+		if recoverErr != nil {
+			if errors.Is(recoverErr, ErrRecoverDeviceNotFound) {
 				logrus.Warnf("Removing engine frontend %s from map: device not found on host", record.Name)
+			} else if errors.Is(recoverErr, ErrRecoveryCancelled) {
+				logrus.Infof("Recovery of engine frontend %s cancelled: evicted by concurrent operation", record.Name)
 			} else {
-				logrus.WithError(err).Warnf("Removing engine frontend %s from map: recovery failed", record.Name)
+				logrus.WithError(recoverErr).Warnf("Removing engine frontend %s from map: recovery failed", record.Name)
 			}
 
 			// Properly shut down the frontend instance (close stopCh,
@@ -1011,9 +1115,29 @@ func (s *Server) recoverEngineFrontends() {
 				logrus.WithError(deleteErr).Warnf("Failed to clean up engine frontend %s during recovery removal", record.Name)
 			}
 
+			// Only remove from map if this entry still belongs to us.
+			// A concurrent EngineFrontendCreate may have already evicted
+			// us and registered a new frontend under the same name.
 			s.Lock()
-			delete(s.engineFrontendMap, record.Name)
+			if s.engineFrontendMap[record.Name] == ef {
+				delete(s.engineFrontendMap, record.Name)
+			}
 			s.Unlock()
+		} else {
+			// Recovery succeeded — verify the ef was not superseded by a
+			// concurrent EngineFrontendCreate while RecoverFromHost was running.
+			s.RLock()
+			current := s.engineFrontendMap[record.Name]
+			s.RUnlock()
+
+			if current != ef {
+				logrus.Warnf("Engine frontend %s was superseded during recovery, cleaning up recovered resources", record.Name)
+				if deleteErr := ef.Delete(spdkClient); deleteErr != nil {
+					logrus.WithError(deleteErr).Warnf("Failed to clean up superseded engine frontend %s", record.Name)
+				}
+			}
 		}
+
+		unlockVolumeHost()
 	}
 }

--- a/pkg/spdk/server_engine.go
+++ b/pkg/spdk/server_engine.go
@@ -68,8 +68,8 @@ func (s *Server) EngineSnapshotMaxCountSet(ctx context.Context, req *spdkrpc.Eng
 // EngineDelete deletes an engine
 func (s *Server) EngineDelete(ctx context.Context, req *spdkrpc.EngineDeleteRequest) (ret *emptypb.Empty, err error) {
 	s.RLock()
-	e := s.engineMap[req.Name]
 	spdkClient := s.spdkClient
+	e := s.engineMap[req.Name]
 	s.RUnlock()
 
 	defer func() {
@@ -175,13 +175,18 @@ func (s *Server) EngineFrontendSwitchOver(ctx context.Context, req *spdkrpc.Engi
 			ef = frontend
 		}
 	}
-	spdkClient := s.spdkClient
 	s.RUnlock()
 
 	if ef == nil {
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find engine frontend or engine %v for target switchover", req.Name)
 	}
 
+	unlockVolumeHost := s.acquireVolumeHostLock(ef.VolumeName)
+	defer unlockVolumeHost()
+
+	s.RLock()
+	spdkClient := s.spdkClient
+	s.RUnlock()
 	if err := ef.SwitchOverTarget(spdkClient, req.EngineName, req.TargetAddress, req.SwitchoverPhase); err != nil {
 		return nil, toSwitchOverGRPCError(err, "failed to switch over target for %s", req.Name)
 	}

--- a/pkg/spdk/server_enginefrontend.go
+++ b/pkg/spdk/server_enginefrontend.go
@@ -27,12 +27,18 @@ func (s *Server) EngineFrontendSuspend(ctx context.Context, req *spdkrpc.EngineF
 
 	s.RLock()
 	ef := s.engineFrontendMap[req.Name]
-	spdkClient := s.spdkClient
 	s.RUnlock()
 
 	if ef == nil {
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find engine frontend %v for suspension", req.Name)
 	}
+
+	unlockVolumeHost := s.acquireVolumeHostLock(ef.VolumeName)
+	defer unlockVolumeHost()
+
+	s.RLock()
+	spdkClient := s.spdkClient
+	s.RUnlock()
 
 	err = ef.Suspend(spdkClient)
 	if err != nil {
@@ -50,12 +56,18 @@ func (s *Server) EngineFrontendResume(ctx context.Context, req *spdkrpc.EngineFr
 
 	s.RLock()
 	ef := s.engineFrontendMap[req.Name]
-	spdkClient := s.spdkClient
 	s.RUnlock()
 
 	if ef == nil {
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "cannot find engine frontend %v for resumption", req.Name)
 	}
+
+	unlockVolumeHost := s.acquireVolumeHostLock(ef.VolumeName)
+	defer unlockVolumeHost()
+
+	s.RLock()
+	spdkClient := s.spdkClient
+	s.RUnlock()
 
 	err = ef.Resume(spdkClient)
 	if err != nil {
@@ -327,7 +339,6 @@ func (s *Server) EngineFrontendCreate(ctx context.Context, req *spdkrpc.EngineFr
 func (s *Server) EngineFrontendDelete(ctx context.Context, req *spdkrpc.EngineFrontendDeleteRequest) (ret *emptypb.Empty, err error) {
 	s.RLock()
 	ef := s.engineFrontendMap[req.Name]
-	spdkClient := s.spdkClient
 	s.RUnlock()
 
 	defer func() {
@@ -343,6 +354,13 @@ func (s *Server) EngineFrontendDelete(ctx context.Context, req *spdkrpc.EngineFr
 	if ef == nil {
 		return &emptypb.Empty{}, nil
 	}
+
+	unlockVolumeHost := s.acquireVolumeHostLock(ef.VolumeName)
+	defer unlockVolumeHost()
+
+	s.RLock()
+	spdkClient := s.spdkClient
+	s.RUnlock()
 
 	if err := ef.Delete(spdkClient); err != nil {
 		return nil, toEngineFrontendLifecycleGRPCError(err, "failed to delete engine frontend %v", req.Name)
@@ -424,7 +442,6 @@ func (s *Server) EngineFrontendExpand(ctx context.Context, req *spdkrpc.EngineFr
 
 	s.RLock()
 	ef := s.engineFrontendMap[req.Name]
-	spdkClient := s.spdkClient
 	s.RUnlock()
 
 	if ef == nil {
@@ -434,6 +451,13 @@ func (s *Server) EngineFrontendExpand(ctx context.Context, req *spdkrpc.EngineFr
 	if types.IsUblkFrontend(ef.Frontend) {
 		return nil, grpcstatus.Errorf(grpccodes.Unimplemented, "cannot expand ublk frontend engine %v", ef.Name)
 	}
+
+	unlockVolumeHost := s.acquireVolumeHostLock(ef.VolumeName)
+	defer unlockVolumeHost()
+
+	s.RLock()
+	spdkClient := s.spdkClient
+	s.RUnlock()
 
 	err = ef.Expand(ctx, spdkClient, req.Size)
 	if err != nil {

--- a/pkg/spdk/server_enginefrontend.go
+++ b/pkg/spdk/server_enginefrontend.go
@@ -232,24 +232,9 @@ func (s *Server) EngineFrontendCreate(ctx context.Context, req *spdkrpc.EngineFr
 		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "frontend %v is not supported", req.Frontend)
 	}
 
-	s.Lock()
-	_, ok := s.engineFrontendMap[req.Name]
-	if ok {
-		s.Unlock()
-		return nil, grpcstatus.Errorf(grpccodes.AlreadyExists, "engine frontend %v already exists", req.Name)
-	}
-	if existing := s.engineFrontendByVolumeName(req.VolumeName); existing != nil {
-		s.Unlock()
-		return nil, grpcstatus.Errorf(grpccodes.AlreadyExists, "engine frontend %v already exists for volume %v", existing.Name, req.VolumeName)
-	}
-
-	ef := NewEngineFrontend(req.Name, req.EngineName, req.VolumeName, req.Frontend, req.SpecSize,
-		req.UblkQueueDepth, req.UblkNumberOfQueue, s.updateChs[types.InstanceTypeEngineFrontend])
-	ef.metadataDir = s.metadataDir
-
-	spdkClient := s.spdkClient
-	s.Unlock()
-
+	// Derive and validate targetAddress BEFORE evicting any Pending recovery
+	// ef, so that a malformed address does not permanently cancel a valid
+	// ongoing recovery.
 	targetAddress := req.TargetAddress
 	// When disableFrontend=True, the manager passes an empty target address
 	// because the engine's NVMe-oF target port is 0 (no listener exposed).
@@ -262,8 +247,80 @@ func (s *Server) EngineFrontendCreate(ctx context.Context, req *spdkrpc.EngineFr
 			targetAddress = net.JoinHostPort(podIP, strconv.Itoa(types.SPDKServicePort))
 		}
 	}
+	// Validate the address format. ef.Create() would reject this with a hard
+	// error (ErrEngineFrontendCreateInvalidArgument), but at that point we
+	// may have already evicted a Pending recovery ef.
+	if _, _, splitErr := splitHostPort(targetAddress); splitErr != nil {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "invalid target address %v: %v", targetAddress, splitErr)
+	}
+
+	s.Lock()
+
+	var evictedEfs []*EngineFrontend
+
+	if existing, ok := s.engineFrontendMap[req.Name]; ok {
+		// If the conflicting ef is still recovering (Pending state from
+		// async recovery), the new Create takes priority — evict it.
+		// We only mark state and remove from map here; the recovery
+		// goroutine will detect the state/map change and handle Delete
+		// sequentially after RecoverFromHost returns, avoiding concurrent
+		// access to the initiator.
+		//
+		// Keep metadataDir intact for now. After Create() we decide:
+		// - Create succeeded → clear metadataDir so the old ef's Delete
+		//   does not remove the NEW persistence record (same volumeName key).
+		// - Create failed with runtime error → keep metadataDir so Delete
+		//   removes the stale old record that would cause bad recovery.
+		existing.Lock()
+		if existing.State == types.InstanceStatePending {
+			existing.State = types.InstanceStateTerminating
+			existing.Unlock()
+			delete(s.engineFrontendMap, req.Name)
+			evictedEfs = append(evictedEfs, existing)
+		} else {
+			existing.Unlock()
+			s.Unlock()
+			return nil, grpcstatus.Errorf(grpccodes.AlreadyExists, "engine frontend %v already exists", req.Name)
+		}
+	}
+	if existing := s.engineFrontendByVolumeName(req.VolumeName); existing != nil {
+		existing.Lock()
+		if existing.State == types.InstanceStatePending {
+			existing.State = types.InstanceStateTerminating
+			existing.Unlock()
+			delete(s.engineFrontendMap, existing.Name)
+			evictedEfs = append(evictedEfs, existing)
+		} else {
+			existing.Unlock()
+			s.Unlock()
+			return nil, grpcstatus.Errorf(grpccodes.AlreadyExists, "engine frontend %v already exists for volume %v", existing.Name, req.VolumeName)
+		}
+	}
+
+	ef := NewEngineFrontend(req.Name, req.EngineName, req.VolumeName, req.Frontend, req.SpecSize,
+		req.UblkQueueDepth, req.UblkNumberOfQueue, s.updateChs[types.InstanceTypeEngineFrontend])
+	ef.metadataDir = s.metadataDir
+
+	s.Unlock()
+
+	// Hold the per-volume host lock so that if the async recovery goroutine
+	// is still performing host NVMe/dm operations for this volume, we wait
+	// for it to finish before starting our own. The lock is held through
+	// map registration so that a second concurrent Create for the same
+	// volume cannot start host operations before we register.
+	unlockVolumeHost := s.acquireVolumeHostLock(req.VolumeName)
+	defer unlockVolumeHost()
+
+	s.RLock()
+	spdkClient := s.spdkClient
+	s.RUnlock()
 
 	ret, createErr := ef.Create(spdkClient, targetAddress)
+	for _, evicted := range evictedEfs {
+		if createErr == nil && evicted.VolumeName == req.VolumeName {
+			evicted.setMetadataDir("")
+		}
+	}
 
 	// Distinguish hard errors (validation / precondition) from runtime
 	// failures (e.g. NVMe initiator can't connect).  Hard errors are
@@ -273,6 +330,26 @@ func (s *Server) EngineFrontendCreate(ctx context.Context, req *spdkrpc.EngineFr
 	if createErr != nil &&
 		(errors.Is(createErr, ErrEngineFrontendCreateInvalidArgument) ||
 			errors.Is(createErr, ErrEngineFrontendCreatePrecondition)) {
+		// Hard error — Create did not mutate anything.  Restore the
+		// evicted efs so valid ongoing recoveries are not permanently lost.
+		if len(evictedEfs) > 0 {
+			s.Lock()
+			for _, evicted := range evictedEfs {
+				evicted.Lock()
+				evicted.State = types.InstanceStatePending
+				evicted.Unlock()
+				// Only restore if both the name and volume slots are still free.
+				// A concurrent Create for the same volume (different name) could
+				// have registered while we were in-flight, and blindly restoring
+				// would violate the one-ef-per-volume map invariant.
+				if _, taken := s.engineFrontendMap[evicted.Name]; !taken {
+					if s.engineFrontendByVolumeName(evicted.VolumeName) == nil {
+						s.engineFrontendMap[evicted.Name] = evicted
+					}
+				}
+			}
+			s.Unlock()
+		}
 		return nil, toEngineFrontendCreateGRPCError(createErr, "failed to create engine frontend %v", req.Name)
 	}
 
@@ -290,6 +367,35 @@ func (s *Server) EngineFrontendCreate(ctx context.Context, req *spdkrpc.EngineFr
 		winner = existing
 	}
 	if duplicateName || duplicateVolume {
+		// If the conflicting ef is still recovering (inserted by async
+		// recovery between our first check and now), the new Create wins.
+		// Only mark state and remove from map; the recovery goroutine
+		// will handle Delete sequentially after RecoverFromHost returns.
+		if winner != nil {
+			winner.Lock()
+			if winner.State == types.InstanceStatePending {
+				winner.State = types.InstanceStateTerminating
+				// Only clear metadataDir when Create succeeded AND the winner
+				// shares the same volumeName. Records are keyed by volumeName,
+				// so only same-volume records collide. Different-volume winners
+				// must keep metadataDir so Delete removes their own record.
+				if createErr == nil && winner.VolumeName == ef.VolumeName {
+					winner.setMetadataDirLocked("")
+				}
+				winner.Unlock()
+
+				delete(s.engineFrontendMap, winner.Name)
+				s.engineFrontendMap[req.Name] = ef
+				s.Unlock()
+
+				if createErr != nil {
+					return ef.Get(), nil
+				}
+				return ret, nil
+			}
+			winner.Unlock()
+		}
+
 		s.Unlock()
 		// The race loser holds a fully-created frontend with real SPDK
 		// resources (bdevs, NVMe controllers, etc.). Clean them up so
@@ -300,7 +406,7 @@ func (s *Server) EngineFrontendCreate(ctx context.Context, req *spdkrpc.EngineFr
 		// When volumeNames differ, each has its own directory and the
 		// loser should clean up its own record.
 		if winner != nil && ef.VolumeName == winner.VolumeName {
-			ef.metadataDir = ""
+			ef.setMetadataDir("")
 		}
 		if deleteErr := ef.Delete(spdkClient); deleteErr != nil {
 			logrus.WithError(deleteErr).Warnf("Failed to clean up race-loser engine frontend %v", req.Name)
@@ -311,10 +417,12 @@ func (s *Server) EngineFrontendCreate(ctx context.Context, req *spdkrpc.EngineFr
 		// Hold the winner's read lock to prevent concurrent mutations
 		// (e.g. Delete, switchover) from racing with the field reads
 		// inside saveEngineFrontendRecord.
-		if winner != nil && winner.metadataDir != "" && ef.VolumeName == winner.VolumeName {
+		if winner != nil && ef.VolumeName == winner.VolumeName {
 			winner.RLock()
-			if err := saveEngineFrontendRecord(winner.metadataDir, winner); err != nil {
-				logrus.WithError(err).Warnf("Failed to re-persist winner engine frontend %v record after race", winner.Name)
+			if metadataDir := winner.metadataDir; metadataDir != "" {
+				if err := saveEngineFrontendRecord(metadataDir, winner); err != nil {
+					logrus.WithError(err).Warnf("Failed to re-persist winner engine frontend %v record after race", winner.Name)
+				}
 			}
 			winner.RUnlock()
 		}

--- a/pkg/spdk/server_verify_test.go
+++ b/pkg/spdk/server_verify_test.go
@@ -374,6 +374,7 @@ func (s *TestSuite) TestEngineFrontendCreateReturnsAlreadyExistsForDuplicate(c *
 	updateCh := make(chan interface{}, 1)
 
 	existing := NewEngineFrontend("ef-dup", "engine-a", "vol-a", lhtypes.FrontendSPDKTCPNvmf, 1024, 0, 0, updateCh)
+	existing.State = lhtypes.InstanceStateRunning
 
 	srv := &Server{
 		engineFrontendMap: map[string]*EngineFrontend{
@@ -586,4 +587,95 @@ func (s *TestSuite) TestEngineFrontendDeleteWaitsForVolumeHostLock(c *C) {
 	case <-time.After(time.Second):
 		c.Fatal("delete did not resume after releasing the per-volume host lock")
 	}
+}
+
+func (s *TestSuite) TestEngineFrontendCreateInvalidAddressDoesNotEvictPendingEf(c *C) {
+	fmt.Println("Testing EngineFrontendCreate with invalid address does not evict a Pending frontend")
+
+	updateCh := make(chan interface{}, 1)
+	existing := NewEngineFrontend("ef-recovering", "engine-a", "vol-a", lhtypes.FrontendSPDKTCPNvmf, 1024, 0, 0, updateCh)
+	// State is Pending (the default from NewEngineFrontend), simulating an
+	// in-progress async recovery.
+
+	srv := &Server{
+		engineFrontendMap: map[string]*EngineFrontend{
+			"ef-recovering": existing,
+		},
+		volumeHostLocks: map[string]*volumeHostLockEntry{},
+		updateChs: map[lhtypes.InstanceType]chan interface{}{
+			lhtypes.InstanceTypeEngineFrontend: updateCh,
+		},
+	}
+
+	// Use an un-bracketed IPv6 address that splitHostPort rejects.
+	_, err := srv.EngineFrontendCreate(context.Background(), &spdkrpc.EngineFrontendCreateRequest{
+		Name:          "ef-recovering",
+		EngineName:    "engine-b",
+		VolumeName:    "vol-a",
+		Frontend:      lhtypes.FrontendSPDKTCPNvmf,
+		SpecSize:      2048,
+		TargetAddress: "2001:db8::1:9502",
+	})
+	c.Assert(err, NotNil)
+	st, ok := grpcstatus.FromError(err)
+	c.Assert(ok, Equals, true)
+	c.Assert(st.Code(), Equals, grpccodes.InvalidArgument)
+
+	// The existing Pending frontend must still be in the map, untouched.
+	srv.RLock()
+	ef := srv.engineFrontendMap["ef-recovering"]
+	srv.RUnlock()
+	c.Assert(ef, Equals, existing)
+	c.Assert(ef.State, Equals, lhtypes.InstanceState(lhtypes.InstanceStatePending))
+}
+
+func (s *TestSuite) TestEngineFrontendCreateEvictsMultiplePendingRecoveries(c *C) {
+	fmt.Println("Testing EngineFrontendCreate evicts both name and volume Pending recoveries in one request")
+
+	updateCh := make(chan interface{}, 1)
+	sameName := NewEngineFrontend("ef-new", "engine-old-name", "vol-old", lhtypes.FrontendSPDKTCPNvmf, 1024, 0, 0, updateCh)
+	sameName.metadataDir = "/tmp/name-recovery"
+	sameVolume := NewEngineFrontend("ef-old-volume", "engine-old-volume", "vol-new", lhtypes.FrontendSPDKTCPNvmf, 1024, 0, 0, updateCh)
+	sameVolume.metadataDir = "/tmp/volume-recovery"
+
+	srv := &Server{
+		engineFrontendMap: map[string]*EngineFrontend{
+			sameName.Name:   sameName,
+			sameVolume.Name: sameVolume,
+		},
+		volumeHostLocks: map[string]*volumeHostLockEntry{},
+		updateChs: map[lhtypes.InstanceType]chan interface{}{
+			lhtypes.InstanceTypeEngineFrontend: updateCh,
+		},
+	}
+
+	resp, err := srv.EngineFrontendCreate(context.Background(), &spdkrpc.EngineFrontendCreateRequest{
+		Name:       "ef-new",
+		EngineName: "engine-new",
+		VolumeName: "vol-new",
+		Frontend:   lhtypes.FrontendSPDKTCPNvmf,
+		SpecSize:   2048,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(resp, NotNil)
+
+	srv.RLock()
+	created := srv.engineFrontendMap["ef-new"]
+	_, sameVolumeStillMapped := srv.engineFrontendMap["ef-old-volume"]
+	srv.RUnlock()
+
+	c.Assert(created, NotNil)
+	c.Assert(created, Not(Equals), sameName)
+	c.Assert(created.VolumeName, Equals, "vol-new")
+	c.Assert(sameVolumeStillMapped, Equals, false)
+
+	sameName.RLock()
+	c.Assert(sameName.State, Equals, lhtypes.InstanceState(lhtypes.InstanceStateTerminating))
+	c.Assert(sameName.metadataDir, Equals, "/tmp/name-recovery")
+	sameName.RUnlock()
+
+	sameVolume.RLock()
+	c.Assert(sameVolume.State, Equals, lhtypes.InstanceState(lhtypes.InstanceStateTerminating))
+	c.Assert(sameVolume.metadataDir, Equals, "")
+	sameVolume.RUnlock()
 }

--- a/pkg/spdk/server_verify_test.go
+++ b/pkg/spdk/server_verify_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
+	"time"
 
 	cockroacherrors "github.com/cockroachdb/errors"
 	grpccodes "google.golang.org/grpc/codes"
@@ -340,6 +342,7 @@ func (s *TestSuite) TestEngineFrontendCreateRegistersNewFrontend(c *C) {
 
 	srv := &Server{
 		engineFrontendMap: map[string]*EngineFrontend{},
+		volumeHostLocks:   map[string]*volumeHostLockEntry{},
 		updateChs: map[lhtypes.InstanceType]chan interface{}{
 			lhtypes.InstanceTypeEngineFrontend: make(chan interface{}, 1),
 		},
@@ -376,6 +379,7 @@ func (s *TestSuite) TestEngineFrontendCreateReturnsAlreadyExistsForDuplicate(c *
 		engineFrontendMap: map[string]*EngineFrontend{
 			"ef-dup": existing,
 		},
+		volumeHostLocks: map[string]*volumeHostLockEntry{},
 		updateChs: map[lhtypes.InstanceType]chan interface{}{
 			lhtypes.InstanceTypeEngineFrontend: updateCh,
 		},
@@ -406,6 +410,7 @@ func (s *TestSuite) TestEngineFrontendCreateDoesNotRegisterFailedFrontend(c *C) 
 
 	srv := &Server{
 		engineFrontendMap: map[string]*EngineFrontend{},
+		volumeHostLocks:   map[string]*volumeHostLockEntry{},
 		updateChs: map[lhtypes.InstanceType]chan interface{}{
 			lhtypes.InstanceTypeEngineFrontend: make(chan interface{}, 1),
 		},
@@ -493,6 +498,7 @@ func (s *TestSuite) TestEngineFrontendLifecycleRPCsMapKnownErrors(c *C) {
 			engineFrontendMap: map[string]*EngineFrontend{
 				"ef-test": ef,
 			},
+			volumeHostLocks: map[string]*volumeHostLockEntry{},
 		}
 	}
 
@@ -529,4 +535,55 @@ func (s *TestSuite) TestEngineFrontendLifecycleRPCsMapKnownErrors(c *C) {
 	st, ok = grpcstatus.FromError(err)
 	c.Assert(ok, Equals, true)
 	c.Assert(st.Code(), Equals, grpccodes.FailedPrecondition)
+}
+
+func (s *TestSuite) TestEngineFrontendDeleteWaitsForVolumeHostLock(c *C) {
+	ef := NewEngineFrontend("ef-test", "engine-a", "vol-a", lhtypes.FrontendEmpty, 1024, 0, 0, make(chan interface{}, 1))
+	srv := &Server{
+		engineFrontendMap: map[string]*EngineFrontend{
+			"ef-test": ef,
+		},
+		volumeHostLocks: map[string]*volumeHostLockEntry{},
+	}
+
+	// Pre-acquire the per-volume lock to simulate an ongoing operation.
+	unlockVolumeHost := srv.acquireVolumeHostLock("vol-a")
+
+	// Hold the server write lock as a scheduling barrier.
+	// EngineFrontendDelete calls s.RLock() before acquireVolumeHostLock,
+	// so the goroutine will block at s.RLock() until we release the
+	// write lock, proving it has been scheduled and is inside Delete.
+	srv.Lock()
+
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		_, err := srv.EngineFrontendDelete(context.Background(), &spdkrpc.EngineFrontendDeleteRequest{Name: "ef-test"})
+		done <- err
+	}()
+
+	// Wait for the goroutine to be scheduled.
+	<-started
+
+	// Release the write lock so the goroutine proceeds past s.RLock().
+	// It will then reach acquireVolumeHostLock and block on the mutex
+	// (the only remaining blocking call before ef.Delete).
+	srv.Unlock()
+	runtime.Gosched()
+
+	select {
+	case err := <-done:
+		c.Fatalf("delete should wait for the per-volume host lock, got early result: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	unlockVolumeHost()
+
+	select {
+	case err := <-done:
+		c.Assert(err, IsNil)
+	case <-time.After(time.Second):
+		c.Fatal("delete did not resume after releasing the per-volume host lock")
+	}
 }

--- a/pkg/spdk/types.go
+++ b/pkg/spdk/types.go
@@ -88,6 +88,10 @@ var (
 	// ErrRecoverDeviceNotFound indicates the NVMe device was not found on the
 	// host during recovery. The persisted record should be removed.
 	ErrRecoverDeviceNotFound = errors.New("device not found on host during recovery")
+	// ErrRecoveryCancelled indicates that recovery was aborted because a
+	// concurrent operation (e.g. EngineFrontendCreate) changed the ef state
+	// from Pending, meaning host-level operations should not proceed.
+	ErrRecoveryCancelled = errors.New("recovery cancelled by concurrent operation")
 )
 
 var (


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13185

#### What this PR does / why we need it:

When an instance-manager pod restarts with persisted engine frontend records referencing unreachable NVMe-TCP targets, the synchronous recoverEngineFrontends() blocks gRPC startup, exceeding the liveness probe threshold and causing an infinite pod create/delete loop.

The fix runs recovery as a goroutine so gRPC serves immediately. A TCP dial pre-check (5s timeout) in the recovery path detects unreachable targets early, avoiding the full 60s nvme-connect retry loop. Since recovery now runs concurrently with incoming gRPC requests, EngineFrontendCreate may race with the recovery goroutine for the same volume. To handle this safely, Create checks whether a conflicting map entry is still in Pending state (i.e. mid-recovery) and if so marks it Terminating and removes it from the map — letting the recovery goroutine perform the actual resource teardown sequentially after RecoverFromHost returns, which avoids concurrent access to the NVMe initiator. The recovery loop itself verifies map ownership (pointer equality) before deleting entries in both the failure and success paths, so it never accidentally removes a new frontend that was registered by a concurrent Create under the same name or volume.


#### Special notes for your reviewer:

#### Additional documentation or context
