### PR TITLE
fix(recovery): verify the NVMe target is reachable during recovery

### DIFF
--- a/pkg/spdk/enginefrontend.go
+++ b/pkg/spdk/enginefrontend.go
@@ -2719,6 +2719,21 @@ func (ef *EngineFrontend) RecoverFromHost(spdkClient *spdkclient.Client) error {
 			}
 		}
 
+		// Verify the NVMe target is actually reachable. The NVMe device may
+		// still appear in sysfs (kernel ctrl_loss_tmo not expired) even though
+		// the target process is dead (e.g., IM pod restarted). A stale device
+		// would cause I/O errors on the dm device above it.
+		detectedAddr := i.GetTransportAddress()
+		detectedPort := i.GetTransportServiceID()
+		if detectedAddr != "" && detectedPort != "" {
+			targetAddr := net.JoinHostPort(detectedAddr, detectedPort)
+			if dialErr := ef.checkTargetReachable(targetAddr); dialErr != nil {
+				ef.log.WithError(dialErr).Warnf("NVMe device found in sysfs but target %s is not reachable, device is stale", targetAddr)
+				recoverErr = errors.Wrapf(dialErr, "NVMe/TCP target %s is not reachable during recovery (stale device in sysfs)", targetAddr)
+				return recoverErr
+			}
+		}
+
 		// Check cancellation before loading the dm-device endpoint.
 		// A concurrent EngineFrontendCreate may have evicted us during
 		// the preceding reconnect or sysfs scan.


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13215


#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
