### PR TITLE
fix: ensure isBDF() matches only whole strings

### DIFF
--- a/pkg/spdk/disk/types.go
+++ b/pkg/spdk/disk/types.go
@@ -124,7 +124,7 @@ func getDiskDriverForPath(diskDriver commontypes.DiskDriver, diskPath string) (c
 }
 
 func isBDF(addr string) bool {
-	bdfFormat := "[a-f0-9]{4}:[a-f0-9]{2}:[a-f0-9]{2}\\.[a-f0-9]{1}"
+	bdfFormat := "^[a-f0-9]{4}:[a-f0-9]{2}:[a-f0-9]{2}\\.[a-f0-9]{1}$"
 	bdfPattern := regexp.MustCompile(bdfFormat)
 	return bdfPattern.MatchString(addr)
 }

--- a/pkg/spdk/disk/types_test.go
+++ b/pkg/spdk/disk/types_test.go
@@ -84,3 +84,29 @@ func (s *TestSuite) TestIsUioPciGeneric(c *C) {
 		c.Assert(result, Equals, tc.expected, Commentf("Expected %v for driver %s, got %v", tc.expected, tc.driver, result))
 	}
 }
+
+func (s *TestSuite) TestIsBDF(c *C) {
+	fmt.Println("Testing isBDF with various path strings")
+
+	testCases := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "BDF path",
+			path:     "0000:00:10.0",
+			expected: true,
+		},
+		{
+			name:     "/dev/disk/by-path path",
+			path:     "/dev/disk/by-path/pci-0000:00:10.0-nvme-1",
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		c.Logf("Running test case: %s", tc.name)
+		result := isBDF(tc.path)
+		c.Assert(result, Equals, tc.expected, Commentf("Expected %v for path %s, got %v", tc.expected, tc.path, result))
+	}
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/13228

#### What this PR does / why we need it:
Add a V2/block disk using a `/dev/disk/by-path/pci-*` path, e.g. `/dev/disk/by-path/pci-0000:00:10.0-nvme-1`. Longhorn will incorrectly think that this is a BDF path, because it sees `0000:00:10.0` in the middle, and will fail to add the disk.

We can fix this by tightening up the regex in `isBDF()` to match only whole strings.

#### Special notes for your reviewer:

#### Additional documentation or context
