### PR TITLE
fix(backup): retry opening NVMe device on ENXIO race

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,12 @@ RUN zypper -n install cmake curl wget gcc13 unzip tar xsltproc docbook-xsl-style
               e2fsprogs xfsprogs util-linux-systemd libcmocka-devel device-mapper procps jq git && \
     rm -rf /var/cache/zypp/*
 
+# Add repo for nasm package
+RUN for i in {1..10}; do \
+        zypper -n addrepo --refresh https://download.opensuse.org/repositories/devel:tools:compiler/openSUSE_Factory/devel:tools:compiler.repo && \
+        zypper --gpg-auto-import-keys ref && break || sleep 1; \
+    done
+
 RUN curl -sSL "https://golang.org/dl/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tar.gz \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz

--- a/pkg/spdk/backing_image.go
+++ b/pkg/spdk/backing_image.go
@@ -570,7 +570,7 @@ func (bi *BackingImage) prepareBackingImageSnapshot(spdkClient *spdkclient.Clien
 		}
 	}()
 
-	headFh, err := openFile(headInitiator.Endpoint(), os.O_RDWR, 0666)
+	headFh, err := openNVMeDeviceWithRetry(bi.log, headInitiator.Endpoint(), os.O_RDWR, 0666)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open NVMe device %v for lvol bdev %v", headInitiator.Endpoint(), backingImageTempHeadName)
 	}
@@ -742,7 +742,7 @@ func (bi *BackingImage) prepareFromSync(targetFh *os.File, fromAddress, srcLvsUU
 	}()
 
 	bi.log.Infof("Opening NVMe device %v", i.Endpoint())
-	srcFh, err := openFile(i.Endpoint(), os.O_RDWR, 0666)
+	srcFh, err := openNVMeDeviceWithRetry(bi.log, i.Endpoint(), os.O_RDWR, 0666)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open NVMe device %v for source backing image %v in lvsUUID %v with address %v", i.Endpoint(), bi.Name, srcLvsUUID, exposedSnapshotLvolAddress)
 	}

--- a/pkg/spdk/backup.go
+++ b/pkg/spdk/backup.go
@@ -6,11 +6,14 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
+
+	retrygo "github.com/avast/retry-go/v4"
 
 	"github.com/longhorn/backupstore"
 	"github.com/longhorn/go-spdk-helper/pkg/initiator"
@@ -76,6 +79,11 @@ type Backup struct {
 }
 
 var _ backupstore.DeltaBlockBackupOperations = (*Backup)(nil)
+
+const (
+	openDeviceMaxRetries    = 10
+	openDeviceRetryInterval = 500 * time.Millisecond
+)
 
 // NewBackup creates a new backup instance
 func NewBackup(spdkClient *spdkclient.Client, backupName, volumeName, snapshotName string, replica *Replica, superiorPortAllocator *commonbitmap.Bitmap, onTerminal func()) (*Backup, error) {
@@ -232,7 +240,30 @@ func (b *Backup) OpenSnapshot(snapshotName, volumeName string) (err error) {
 	b.initiator = i
 
 	b.log.Infof("Opening NVMe device %v", b.initiator.Endpoint())
-	devFh, err := openFile(b.initiator.Endpoint(), os.O_RDONLY, 0666)
+	// After the NVMe-oF controller connects, the kernel may not yet have
+	// instantiated the namespace block device, causing open() to return ENXIO.
+	// Retry briefly to absorb this race; other errors are not transient.
+	var devFh *os.File
+	err = retrygo.Do(
+		func() error {
+			var openErr error
+			devFh, openErr = openFile(b.initiator.Endpoint(), os.O_RDONLY, 0666)
+			if openErr != nil {
+				if !errors.Is(openErr, syscall.ENXIO) {
+					return retrygo.Unrecoverable(openErr)
+				}
+				return openErr
+			}
+			return nil
+		},
+		retrygo.Attempts(openDeviceMaxRetries),
+		retrygo.Delay(openDeviceRetryInterval),
+		retrygo.DelayType(retrygo.FixedDelay),
+		retrygo.LastErrorOnly(true),
+		retrygo.OnRetry(func(n uint, err error) {
+			b.log.Warnf("NVMe device %v not ready (ENXIO), retrying (%d/%d)", b.initiator.Endpoint(), n+1, openDeviceMaxRetries)
+		}),
+	)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open NVMe device %v for snapshot lvol bdev %v", b.initiator.Endpoint(), lvolName)
 	}

--- a/pkg/spdk/backup.go
+++ b/pkg/spdk/backup.go
@@ -6,14 +6,11 @@ import (
 	"os"
 	"strconv"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
-
-	retrygo "github.com/avast/retry-go/v4"
 
 	"github.com/longhorn/backupstore"
 	"github.com/longhorn/go-spdk-helper/pkg/initiator"
@@ -79,11 +76,6 @@ type Backup struct {
 }
 
 var _ backupstore.DeltaBlockBackupOperations = (*Backup)(nil)
-
-const (
-	openDeviceMaxRetries    = 10
-	openDeviceRetryInterval = 500 * time.Millisecond
-)
 
 // NewBackup creates a new backup instance
 func NewBackup(spdkClient *spdkclient.Client, backupName, volumeName, snapshotName string, replica *Replica, superiorPortAllocator *commonbitmap.Bitmap, onTerminal func()) (*Backup, error) {
@@ -240,30 +232,7 @@ func (b *Backup) OpenSnapshot(snapshotName, volumeName string) (err error) {
 	b.initiator = i
 
 	b.log.Infof("Opening NVMe device %v", b.initiator.Endpoint())
-	// After the NVMe-oF controller connects, the kernel may not yet have
-	// instantiated the namespace block device, causing open() to return ENXIO.
-	// Retry briefly to absorb this race; other errors are not transient.
-	var devFh *os.File
-	err = retrygo.Do(
-		func() error {
-			var openErr error
-			devFh, openErr = openFile(b.initiator.Endpoint(), os.O_RDONLY, 0666)
-			if openErr != nil {
-				if !errors.Is(openErr, syscall.ENXIO) {
-					return retrygo.Unrecoverable(openErr)
-				}
-				return openErr
-			}
-			return nil
-		},
-		retrygo.Attempts(openDeviceMaxRetries),
-		retrygo.Delay(openDeviceRetryInterval),
-		retrygo.DelayType(retrygo.FixedDelay),
-		retrygo.LastErrorOnly(true),
-		retrygo.OnRetry(func(n uint, err error) {
-			b.log.Warnf("NVMe device %v not ready (ENXIO), retrying (%d/%d)", b.initiator.Endpoint(), n+1, openDeviceMaxRetries)
-		}),
-	)
+	devFh, err := openNVMeDeviceWithRetry(b.log, b.initiator.Endpoint(), os.O_RDONLY, 0666)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open NVMe device %v for snapshot lvol bdev %v", b.initiator.Endpoint(), lvolName)
 	}

--- a/pkg/spdk/restore.go
+++ b/pkg/spdk/restore.go
@@ -185,7 +185,7 @@ func (r *Restore) OpenVolumeDev(volDevName string) (fh *os.File, endpoint string
 	r.initiator = i
 
 	r.log.Infof("Opening NVMe device %v", r.initiator.Endpoint())
-	fh, err = openFile(r.initiator.Endpoint(), os.O_RDONLY, 0666)
+	fh, err = openNVMeDeviceWithRetry(r.log, r.initiator.Endpoint(), os.O_RDONLY, 0666)
 	if err != nil {
 		return nil, "", errors.Wrapf(err, "failed to open NVMe device %v for lvol bdev %v", r.initiator.Endpoint(), lvolName)
 	}

--- a/pkg/spdk/restore_engine.go
+++ b/pkg/spdk/restore_engine.go
@@ -100,7 +100,7 @@ func (r *EngineRestore) OpenVolumeDev(_ string) (*os.File, string, error) {
 	endpoint := r.endpoint
 
 	r.log.Infof("Opening NVMe device %v", endpoint)
-	fh, err := os.OpenFile(endpoint, os.O_RDWR|syscall.O_DIRECT, 0666)
+	fh, err := openNVMeDeviceWithRetry(r.log, endpoint, os.O_RDWR|syscall.O_DIRECT, 0666)
 	if err != nil {
 		return nil, "", errors.Wrapf(err, "failed to open NVMe device %v", endpoint)
 	}

--- a/pkg/spdk/util.go
+++ b/pkg/spdk/util.go
@@ -3,9 +3,11 @@ package spdk
 import (
 	"fmt"
 	"net"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -22,6 +24,49 @@ import (
 	helpertypes "github.com/longhorn/go-spdk-helper/pkg/types"
 	helperutil "github.com/longhorn/go-spdk-helper/pkg/util"
 )
+
+const (
+	openDeviceMaxRetries    = 10
+	openDeviceRetryInterval = 500 * time.Millisecond
+)
+
+// warnLogger is the minimal logger surface used by openNVMeDeviceWithRetry so
+// it accepts both logrus.FieldLogger and the package-local SafeLogger.
+type warnLogger interface {
+	Warnf(format string, args ...interface{})
+}
+
+// openNVMeDeviceWithRetry opens an NVMe device endpoint, retrying briefly on
+// ENXIO. After StartNvmeTCPInitiator returns, the kernel may not yet have
+// instantiated the namespace block device, so open() can transiently return
+// ENXIO; other errors are treated as unrecoverable.
+func openNVMeDeviceWithRetry(log warnLogger, endpoint string, flag int, perm os.FileMode) (*os.File, error) {
+	var fh *os.File
+	err := retry.Do(
+		func() error {
+			var openErr error
+			fh, openErr = openFile(endpoint, flag, perm)
+			if openErr != nil {
+				if !errors.Is(openErr, syscall.ENXIO) {
+					return retry.Unrecoverable(openErr)
+				}
+				return openErr
+			}
+			return nil
+		},
+		retry.Attempts(openDeviceMaxRetries),
+		retry.Delay(openDeviceRetryInterval),
+		retry.DelayType(retry.FixedDelay),
+		retry.LastErrorOnly(true),
+		retry.OnRetry(func(n uint, err error) {
+			log.Warnf("NVMe device %v not ready (ENXIO), retrying (%d/%d)", endpoint, n+1, openDeviceMaxRetries)
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return fh, nil
+}
 
 func discoverAndConnectNVMeTarget(srcIP string, srcPort int32, maxRetries int, retryInterval time.Duration) (subsystemNQN, controllerName string, err error) {
 	executor, err := helperutil.NewExecutor(commontypes.ProcDirectory)


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13188


#### What this PR does / why we need it:

After the NVMe-oF controller connects, the kernel may not have instantiated the namespace block device yet, causing open() on the device endpoint to return ENXIO. This intermittently fails backup creation right after StartNvmeTCPInitiator returns.

Retry the open up to 10 times with a 500ms fixed delay (5s total) when the error is ENXIO, using retry-go for consistency with the existing retry usage in pkg/spdk/engine.go. Non-ENXIO errors are wrapped in retrygo.Unrecoverable so they fail fast as before.

#### Special notes for your reviewer:

#### Additional documentation or context
