### PR TITLE
fix: avoid setting DEFERRED REMOVE flag for the dm device during EngineFrontend Delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jinzhu/copier v0.4.0
 	github.com/longhorn/backupstore v0.0.0-20260525102750-1ed7dde50b68
 	github.com/longhorn/go-common-libs v0.0.0-20260502161928-1e84fa75a8f1
-	github.com/longhorn/go-spdk-helper v0.6.3-0.20260601101353-0be728aae70e
+	github.com/longhorn/go-spdk-helper v0.6.3-0.20260617073059-6809190e0f78
 	github.com/longhorn/types v0.0.0-20260514154143-1dfb06f48eeb
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/longhorn/backupstore v0.0.0-20260525102750-1ed7dde50b68 h1:p05ShG/5Gr
 github.com/longhorn/backupstore v0.0.0-20260525102750-1ed7dde50b68/go.mod h1:sJ3YQBK1exSY+Gep0cKaQhZ9f2rOem2hy6NTOk7iFg8=
 github.com/longhorn/go-common-libs v0.0.0-20260502161928-1e84fa75a8f1 h1:sjDswhcTrEqeXSjcHjaeccYT1v1WW9wNHB3fWFArM38=
 github.com/longhorn/go-common-libs v0.0.0-20260502161928-1e84fa75a8f1/go.mod h1:+aXFI8DmHTX4Az9pZF16/XKfrVKWIESJjw+hcxdMslw=
-github.com/longhorn/go-spdk-helper v0.6.3-0.20260601101353-0be728aae70e h1:EsEn30wYJccl6W0Y0WLOqtU7xkS63RLcKNa6m0I3rbM=
-github.com/longhorn/go-spdk-helper v0.6.3-0.20260601101353-0be728aae70e/go.mod h1:ZxbMkGsbC2TpzuGLjn9yXXExolt8/F3dl/C8O9/Qa7s=
+github.com/longhorn/go-spdk-helper v0.6.3-0.20260617073059-6809190e0f78 h1:q/CdSTA519Jtxa/tI2BM06izcHz1Z4ci229UVJyg08c=
+github.com/longhorn/go-spdk-helper v0.6.3-0.20260617073059-6809190e0f78/go.mod h1:ZxbMkGsbC2TpzuGLjn9yXXExolt8/F3dl/C8O9/Qa7s=
 github.com/longhorn/types v0.0.0-20260514154143-1dfb06f48eeb h1:kj/ag7xC8l9QewJ6tpZAWCYRgipYwIOkqPoqY52utW4=
 github.com/longhorn/types v0.0.0-20260514154143-1dfb06f48eeb/go.mod h1:iY4stwsoG8OwvR0WSZr+YeSOr4YNnoX9+GoG3u+uDFw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/pkg/spdk/enginefrontend.go
+++ b/pkg/spdk/enginefrontend.go
@@ -748,7 +748,7 @@ func (ef *EngineFrontend) Delete(spdkClient *spdkclient.Client) (err error) {
 	ef.log.WithField("hasInitiator", ef.initiator != nil).Info("Deleting engine frontend")
 
 	if ef.initiator != nil {
-		if _, err := ef.initiator.Stop(spdkClient, true, true, true); err != nil {
+		if _, err := ef.initiator.Stop(spdkClient, true, false, false); err != nil {
 			return err
 		}
 		ef.initiator = nil

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/initiator/initiator.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/initiator/initiator.go
@@ -433,6 +433,14 @@ func (i *Initiator) resumeLinearDmDevice() error {
 }
 
 func (i *Initiator) replaceDmDeviceTarget() error {
+	deferredRemove, err := i.IsDeferredRemoveSet()
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if linear dm device has deferred-remove flag set for initiator %s", i.Name)
+	}
+	if deferredRemove {
+		i.logger.Warn("Trying to reuse the linear dm device that has deferred-remove flag set, the device will be removed after not busy")
+	}
+
 	suspended, err := i.IsSuspended()
 	if err != nil {
 		return errors.Wrapf(err, "failed to check if linear dm device is suspended for initiator %s", i.Name)
@@ -1429,6 +1437,21 @@ func (i *Initiator) IsSuspended() (bool, error) {
 	for _, device := range devices {
 		if device.Name == i.Name {
 			return device.Suspended, nil
+		}
+	}
+	return false, fmt.Errorf("failed to find linear dm device %s", i.Name)
+}
+
+// IsDeferredRemoveSet checks if the linear dm device has the deferred-remove flag set
+func (i *Initiator) IsDeferredRemoveSet() (bool, error) {
+	devices, err := util.DmsetupInfo(i.Name, i.executor)
+	if err != nil {
+		return false, err
+	}
+
+	for _, device := range devices {
+		if device.Name == i.Name {
+			return device.DeferredRemove, nil
 		}
 	}
 	return false, fmt.Errorf("failed to find linear dm device %s", i.Name)

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/util/dmsetup.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/util/dmsetup.go
@@ -143,6 +143,7 @@ type DeviceInfo struct {
 	TableInactive   bool
 	Suspended       bool
 	ReadOnly        bool
+	DeferredRemove  bool
 	Major           uint32
 	Minor           uint32
 	OpenCount       uint32 // Open reference count
@@ -203,8 +204,39 @@ func DmsetupInfo(dmDeviceName string, executor *commonns.Executor) ([]*DeviceInf
 		info.TableLive = strings.Contains(attr, "L")
 		info.TableInactive = strings.Contains(attr, "I")
 
+		// Check deferred-remove flag via non-columns dmsetup info
+		deferredRemove, err := DmsetupInfoDeferredRemove(info.Name, executor)
+		if err == nil {
+			info.DeferredRemove = deferredRemove
+		}
+
 		devices = append(devices, info)
 	}
 
 	return devices, nil
+}
+
+// DmsetupInfoDeferredRemove checks if the device has the deferred-remove flag set
+// by running `dmsetup info <name>` (non-columns format) and parsing the State line.
+func DmsetupInfoDeferredRemove(dmDeviceName string, executor *commonns.Executor) (bool, error) {
+	opts := []string{
+		"info", dmDeviceName,
+	}
+
+	outputStr, err := executor.Execute(nil, dmsetupBinary, opts, types.ExecuteTimeout)
+	if err != nil {
+		return false, err
+	}
+
+	lines := strings.Split(outputStr, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "State:") {
+			if strings.Contains(strings.ToUpper(line), "DEFERRED REMOVE") {
+				return true, nil
+			}
+			return false, nil
+		}
+	}
+
+	return false, fmt.Errorf("failed to find State line in dmsetup info output for %s", dmDeviceName)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -131,7 +131,7 @@ github.com/longhorn/go-common-libs/sync
 github.com/longhorn/go-common-libs/sys
 github.com/longhorn/go-common-libs/types
 github.com/longhorn/go-common-libs/utils
-# github.com/longhorn/go-spdk-helper v0.6.3-0.20260601101353-0be728aae70e
+# github.com/longhorn/go-spdk-helper v0.6.3-0.20260617073059-6809190e0f78
 ## explicit; go 1.25.3
 github.com/longhorn/go-spdk-helper/pkg/initiator
 github.com/longhorn/go-spdk-helper/pkg/jsonrpc


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/13314

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
