### PR TITLE
fix(backup): forward well-known backup parameters through v2 Labels

### DIFF
--- a/pkg/client/client_engine.go
+++ b/pkg/client/client_engine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/longhorn/types/pkg/generated/spdkrpc"
 
 	"github.com/longhorn/longhorn-spdk-engine/pkg/api"
+	"github.com/longhorn/longhorn-spdk-engine/pkg/types"
 	"github.com/longhorn/longhorn-spdk-engine/pkg/util"
 )
 
@@ -433,7 +434,7 @@ func (c *SPDKClient) EngineBackupCreate(req *BackupCreateRequest) (*spdkrpc.Back
 		BackupTarget:         req.BackupTarget,
 		VolumeName:           req.VolumeName,
 		EngineName:           req.EngineName,
-		Labels:               req.Labels,
+		Labels:               types.EncodeBackupParametersIntoLabels(req.Labels, req.Parameters),
 		Credential:           req.Credential,
 		BackingImageName:     req.BackingImageName,
 		BackingImageChecksum: req.BackingImageChecksum,

--- a/pkg/client/client_replica.go
+++ b/pkg/client/client_replica.go
@@ -10,6 +10,7 @@ import (
 	"github.com/longhorn/types/pkg/generated/spdkrpc"
 
 	"github.com/longhorn/longhorn-spdk-engine/pkg/api"
+	"github.com/longhorn/longhorn-spdk-engine/pkg/types"
 	"github.com/longhorn/longhorn-spdk-engine/pkg/util"
 )
 
@@ -656,7 +657,7 @@ func (c *SPDKClient) ReplicaBackupCreate(req *BackupCreateRequest) (*spdkrpc.Bac
 		VolumeName:           req.VolumeName,
 		ReplicaName:          req.ReplicaName,
 		Size:                 int64(req.Size),
-		Labels:               req.Labels,
+		Labels:               types.EncodeBackupParametersIntoLabels(req.Labels, req.Parameters),
 		Credential:           req.Credential,
 		BackingImageName:     req.BackingImageName,
 		BackingImageChecksum: req.BackingImageChecksum,

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -38,7 +38,16 @@ type BackupCreateRequest struct {
 	CompressionMethod    string
 	ConcurrentLimit      int32
 	Labels               []string
-	Credential           map[string]string
+	// Parameters carries well-known backup parameters (e.g. "backup-mode") that
+	// backupstore's DeltaBackupConfig needs but that the v2 spdkrpc.BackupCreateRequest
+	// proto message has no dedicated field for. The client wrappers
+	// (EngineBackupCreate / ReplicaBackupCreate) smuggle these through the
+	// Labels field on the wire; the server side extracts them again before
+	// they can be persisted as user-visible backup labels. See
+	// types.EncodeBackupParametersIntoLabels / ExtractBackupParametersFromLabels
+	// for the recognised keys and the encoder/decoder pair.
+	Parameters map[string]string
+	Credential map[string]string
 }
 
 type BackupRestoreRequest struct {

--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -2047,6 +2047,15 @@ func (e *Engine) BackupCreate(backupName, volumeName, engineName, snapshotName, 
 		}
 	}()
 
+	// NOTE: labels are forwarded to the replica opaquely on purpose. Well-known
+	// backup parameters are smuggled into this slice under a reserved
+	// DNS-qualified prefix by the entry-side client wrapper
+	// (client.EngineBackupCreate via types.EncodeBackupParametersIntoLabels)
+	// and extracted again on the replica-side server
+	// (server_replica.ReplicaBackupCreate via types.ExtractBackupParametersFromLabels).
+	// Do not filter, deduplicate, or normalize labels here or those reserved
+	// entries will silently disappear and callers' intent (e.g. forcing a full
+	// backup) will be lost.
 	recv, err := replicaServiceCli.ReplicaBackupCreate(&client.BackupCreateRequest{
 		BackupName:           backupName,
 		SnapshotName:         snapshotName,

--- a/pkg/spdk/server_replica.go
+++ b/pkg/spdk/server_replica.go
@@ -748,6 +748,14 @@ func (s *Server) ReplicaBackupCreate(ctx context.Context, req *spdkrpc.BackupCre
 		}
 	}
 
+	// The v2 (SPDK) BackupCreateRequest has no dedicated field for backup
+	// parameters such as forcing a full backup, so callers (e.g. longhorn-manager)
+	// smuggle them through the existing Labels field under a reserved
+	// DNS-qualified prefix (see pkg/types). Extract them here so they drive
+	// backupstore's isFullBackup() decision, and remove them from labelMap so
+	// the reserved entries are not persisted as user-visible backup labels.
+	parameters := types.ExtractBackupParametersFromLabels(labelMap)
+
 	s.Lock()
 	defer s.Unlock()
 
@@ -789,9 +797,10 @@ func (s *Server) ReplicaBackupCreate(ctx context.Context, req *spdkrpc.BackupCre
 			Name:        req.SnapshotName,
 			CreatedTime: util.Now(),
 		},
-		DestURL:  req.BackupTarget,
-		DeltaOps: backup,
-		Labels:   labelMap,
+		DestURL:    req.BackupTarget,
+		DeltaOps:   backup,
+		Labels:     labelMap,
+		Parameters: parameters,
 	}
 
 	s.trackBackupLocked(backupName, backup)

--- a/pkg/types/backup_parameters.go
+++ b/pkg/types/backup_parameters.go
@@ -1,0 +1,79 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	lhbackup "github.com/longhorn/go-common-libs/backup"
+)
+
+// backupParameterLabelPrefix is the reserved DNS-qualified prefix used to
+// smuggle well-known backup parameters through the v2 (SPDK) gRPC Labels
+// wire field. Namespacing under "longhorn.io/" avoids colliding with a
+// plain user label that happens to share a parameter's bare name (e.g. a
+// caller tagging their backup with "backup-mode=full" for their own
+// bookkeeping) — such a label is left untouched because it lacks this
+// prefix. It does not protect against a caller deliberately setting a
+// label using the fully-qualified reserved key itself.
+const backupParameterLabelPrefix = "longhorn.io/backup-parameter."
+
+// wellKnownBackupParameterKeys enumerates the backup parameter keys that are
+// forwarded from callers (longhorn-manager via longhorn-instance-manager) into
+// backupstore.DeltaBackupConfig.Parameters for v2 (SPDK) backups.
+//
+// The v2 gRPC BackupCreateRequest (spdkrpc.BackupCreateRequest) has no
+// dedicated field for backup parameters, so these keys are smuggled through
+// the existing Labels field under backupParameterLabelPrefix. See
+// EncodeBackupParametersIntoLabels / ExtractBackupParametersFromLabels for
+// the paired encoder/decoder. Add new keys here to have them flow end-to-end
+// without touching either side individually.
+//
+// Kept unexported so external packages cannot mutate the recognised-key set
+// at runtime; go through the encoder/decoder helpers instead.
+var wellKnownBackupParameterKeys = []string{
+	lhbackup.LonghornBackupParameterBackupMode,
+	lhbackup.LonghornBackupParameterBackupBlockSize,
+}
+
+func isWellKnownBackupParameterKey(key string) bool {
+	for _, k := range wellKnownBackupParameterKeys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// EncodeBackupParametersIntoLabels appends reserved
+// "<backupParameterLabelPrefix><key>=<value>" entries to labels for every
+// well-known parameter present in parameters. It returns labels unchanged if
+// parameters is nil or contains no well-known key. Non-well-known parameter
+// keys are ignored so the wire contract stays explicit.
+func EncodeBackupParametersIntoLabels(labels []string, parameters map[string]string) []string {
+	for _, key := range wellKnownBackupParameterKeys {
+		if value, ok := parameters[key]; ok {
+			labels = append(labels, fmt.Sprintf("%s%s=%s", backupParameterLabelPrefix, key, value))
+		}
+	}
+	return labels
+}
+
+// ExtractBackupParametersFromLabels removes every reserved
+// backupParameterLabelPrefix entry with a well-known suffix from labelMap
+// and returns them as a plain parameters map keyed by the parameter name
+// (prefix stripped). Entries outside the reserved namespace, or reserved
+// entries with unrecognised suffixes, are left untouched so callers'
+// ordinary labels are preserved verbatim. Returns an empty (non-nil) map
+// if labelMap contains no matching entry.
+func ExtractBackupParametersFromLabels(labelMap map[string]string) map[string]string {
+	parameters := map[string]string{}
+	for k, v := range labelMap {
+		key, ok := strings.CutPrefix(k, backupParameterLabelPrefix)
+		if !ok || !isWellKnownBackupParameterKey(key) {
+			continue
+		}
+		parameters[key] = v
+		delete(labelMap, k)
+	}
+	return parameters
+}

--- a/pkg/types/backup_parameters_test.go
+++ b/pkg/types/backup_parameters_test.go
@@ -1,0 +1,144 @@
+package types
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	lhbackup "github.com/longhorn/go-common-libs/backup"
+
+	"github.com/longhorn/longhorn-spdk-engine/pkg/util"
+)
+
+// TestBackupParametersEncodeDecodeRoundTrip exercises the label-smuggling
+// contract used by the v2 (SPDK) backup path: parameters passed by callers
+// (longhorn-manager -> longhorn-instance-manager) must survive being encoded
+// into the Labels wire field and decoded again in longhorn-spdk-engine's
+// server_replica.ReplicaBackupCreate. If either side drops a well-known key,
+// v2 backups silently ignore caller intent (e.g. "backup-mode=full" is
+// treated as incremental) — this is the bug that motivated introducing this
+// helper pair.
+func TestBackupParametersEncodeDecodeRoundTrip(t *testing.T) {
+	parameters := map[string]string{
+		lhbackup.LonghornBackupParameterBackupMode:      string(lhbackup.LonghornBackupModeFull),
+		lhbackup.LonghornBackupParameterBackupBlockSize: "2097152",
+	}
+	userLabels := []string{"longhorn.io/volume-name=vol-a"}
+
+	encoded := EncodeBackupParametersIntoLabels(userLabels, parameters)
+
+	// The encoded wire form must use the reserved DNS-qualified prefix so it
+	// cannot be confused with a user label sharing the plain parameter name.
+	for _, kv := range encoded[len(userLabels):] {
+		if !strings.HasPrefix(kv, backupParameterLabelPrefix) {
+			t.Fatalf("encoded parameter %q does not use reserved prefix %q", kv, backupParameterLabelPrefix)
+		}
+	}
+
+	// Use the real server-side parser (pkg/util.ParseLabels) rather than a
+	// hand-rolled mimic, so this test tracks its actual last-wins/validation
+	// behavior instead of drifting from it.
+	labelMap, err := util.ParseLabels(encoded)
+	if err != nil {
+		t.Fatalf("ParseLabels(%v) returned unexpected error: %v", encoded, err)
+	}
+
+	got := ExtractBackupParametersFromLabels(labelMap)
+	if !reflect.DeepEqual(got, parameters) {
+		t.Fatalf("round-trip parameters = %v; want %v", got, parameters)
+	}
+	// Reserved-prefix entries must be consumed and not linger as
+	// user-visible backup labels.
+	for k := range labelMap {
+		if strings.HasPrefix(k, backupParameterLabelPrefix) {
+			t.Fatalf("extract left reserved key %q behind in labelMap", k)
+		}
+	}
+	if labelMap["longhorn.io/volume-name"] != "vol-a" {
+		t.Fatalf("user label was dropped: %v", labelMap)
+	}
+}
+
+func TestEncodeBackupParametersIntoLabelsIsNoOpWhenEmpty(t *testing.T) {
+	labels := []string{"foo=bar"}
+	got := EncodeBackupParametersIntoLabels(labels, nil)
+	if !reflect.DeepEqual(got, labels) {
+		t.Fatalf("nil parameters mutated labels: %v", got)
+	}
+	got = EncodeBackupParametersIntoLabels(labels, map[string]string{"unrelated": "v"})
+	if !reflect.DeepEqual(got, labels) {
+		t.Fatalf("unrecognised parameter leaked into labels: %v", got)
+	}
+}
+
+func TestExtractBackupParametersFromLabelsIsNoOpWhenAbsent(t *testing.T) {
+	parameters := ExtractBackupParametersFromLabels(nil)
+	if len(parameters) != 0 {
+		t.Fatalf("nil labelMap produced non-empty parameters: %v", parameters)
+	}
+	labelMap := map[string]string{"foo": "bar"}
+	parameters = ExtractBackupParametersFromLabels(labelMap)
+	if len(parameters) != 0 {
+		t.Fatalf("missing well-known keys produced non-empty parameters: %v", parameters)
+	}
+	if labelMap["foo"] != "bar" {
+		t.Fatalf("unrelated label was mutated: %v", labelMap)
+	}
+}
+
+// TestExtractDoesNotHijackPlainUserLabels guards the reserved-prefix
+// contract: a user label whose name coincides with a well-known parameter
+// key (e.g. "backup-mode=incremental") must be preserved verbatim and must
+// NOT be extracted into the parameters map, because it lacks the reserved
+// namespace prefix.
+func TestExtractDoesNotHijackPlainUserLabels(t *testing.T) {
+	labelMap := map[string]string{
+		lhbackup.LonghornBackupParameterBackupMode:      string(lhbackup.LonghornBackupModeIncremental),
+		lhbackup.LonghornBackupParameterBackupBlockSize: "16777216",
+		"unrelated": "v",
+	}
+	original := map[string]string{}
+	for k, v := range labelMap {
+		original[k] = v
+	}
+
+	got := ExtractBackupParametersFromLabels(labelMap)
+	if len(got) != 0 {
+		t.Fatalf("plain user labels were hijacked into parameters: %v", got)
+	}
+	if !reflect.DeepEqual(labelMap, original) {
+		t.Fatalf("plain user labels were mutated: got %v; want %v", labelMap, original)
+	}
+}
+
+// TestExtractIgnoresUnknownReservedKeys ensures the decoder only accepts
+// suffixes registered in wellKnownBackupParameterKeys. An unrecognised entry
+// inside the reserved namespace is left alone so an accidental typo cannot
+// silently disappear into parameters.
+func TestExtractIgnoresUnknownReservedKeys(t *testing.T) {
+	labelMap := map[string]string{
+		backupParameterLabelPrefix + "unknown-key": "v",
+	}
+	got := ExtractBackupParametersFromLabels(labelMap)
+	if len(got) != 0 {
+		t.Fatalf("unknown reserved key leaked into parameters: %v", got)
+	}
+	if labelMap[backupParameterLabelPrefix+"unknown-key"] != "v" {
+		t.Fatalf("unknown reserved key was unexpectedly removed: %v", labelMap)
+	}
+}
+
+// TestEncodedKeysPassParseLabelsValidation guards against the reserved keys
+// being invalid per util.ParseLabels' validation rules (which reject
+// non-qualified names) — a regression here would silently disable the wire
+// contract with a startup-time ParseLabels error.
+func TestEncodedKeysPassParseLabelsValidation(t *testing.T) {
+	parameters := map[string]string{
+		lhbackup.LonghornBackupParameterBackupMode:      string(lhbackup.LonghornBackupModeFull),
+		lhbackup.LonghornBackupParameterBackupBlockSize: "2097152",
+	}
+	encoded := EncodeBackupParametersIntoLabels(nil, parameters)
+	if _, err := util.ParseLabels(encoded); err != nil {
+		t.Fatalf("encoded reserved labels %v failed ParseLabels validation: %v", encoded, err)
+	}
+}


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13526

#### What this PR does / why we need it:

The v2 (SPDK) BackupCreateRequest gRPC message has no dedicated field for backup parameters, so caller intent such as forcing a full backup ("backup-mode=full") is dropped between longhorn-instance-manager's proxy and longhorn-spdk-engine. As a result, v2 volumes stay Faulted after a "new full backup" attempt because backupstore's isFullBackup() sees an empty Parameters map and falls back to incremental.

Introduce a small pkg/types helper pair that smuggles well-known backup parameters through the existing Labels wire field under a reserved DNS-qualified prefix ("longhorn.io/backup-parameter."). The client wrappers EngineBackupCreate / ReplicaBackupCreate encode BackupCreateRequest.Parameters into Labels; ReplicaBackupCreate on the server side extracts them back into backupstore.DeltaBackupConfig. Parameters and removes them from the persisted user-visible labels.

The reserved namespace prevents a plain user label sharing a parameter's bare name (e.g. a caller tagging its backup with "backup-mode=full" for its own bookkeeping) from being mistaken for internal parameter intent. The engine-hop keeps forwarding labels opaquely, so the smuggled entries survive Engine.BackupCreate -> ReplicaBackupCreate without any special handling; a NOTE comment there documents this invariant.

#### Special notes for your reviewer:

#### Additional documentation or context
