### PR TITLE
fix(engine): keep replica setup failures scoped

### DIFF
--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -945,12 +945,8 @@ func (e *Engine) ReplicaAdd(spdkClient *spdkclient.Client, dstReplicaName, dstRe
 
 	if frontendSuspendResumeWrapper != nil {
 		if wrapErr := frontendSuspendResumeWrapper(startFn); wrapErr != nil {
-			// The wrapper itself may fail (e.g. suspend or resume failure).
-			// If the inner startFn already set engineErr, those are captured
-			// via closure.
-			if err == nil && engineErr == nil {
-				engineErr = wrapErr
-			}
+			// startFn captures fatal engine errors in engineErr. The wrapper
+			// returns the work error, so keep setup failures replica-scoped.
 			setupErr = wrapErr
 		}
 	} else {

--- a/pkg/spdk_test.go
+++ b/pkg/spdk_test.go
@@ -4777,6 +4777,32 @@ func (s *TestSuite) TestSPDKEngineFrontendReplicaAddErrorHandling(c *C) {
 	c.Assert(err, IsNil)
 	err = f.Close()
 	c.Assert(err, IsNil)
+
+	// 7. Test synchronous destination setup failure through the frontend wrapper.
+	// Reuse a reachable replica address with a missing replica name so
+	// ReplicaRebuildingDstStart fails deterministically without a transport timeout.
+	missingReplicaName := fmt.Sprintf("%s-replica-missing", volumeName)
+	missingReplicaAddress := replica2Address
+	err = spdkCli.EngineFrontendReplicaAdd(engineFrontendName, missingReplicaName, missingReplicaAddress, defaultTestFastSync, "", "", "")
+	c.Assert(err, NotNil)
+
+	engine, err = spdkCli.EngineGet(engineName)
+	c.Assert(err, IsNil)
+	c.Assert(engine.State, Equals, types.InstanceStateRunning)
+	c.Assert(engine.ErrorMsg, Equals, "")
+	c.Assert(engine.ReplicaModeMap[missingReplicaName], Equals, types.ModeERR)
+	for _, replicaName := range replicaNames {
+		c.Assert(engine.ReplicaModeMap[replicaName], Equals, types.ModeRW)
+	}
+
+	engineFrontend, err = spdkCli.EngineFrontendGet(engineFrontendName)
+	c.Assert(err, IsNil)
+	c.Assert(engineFrontend.State, Equals, types.InstanceStateRunning)
+	c.Assert(engineFrontend.ErrorMsg, Equals, "")
+	c.Assert(engineFrontend.Endpoint, Equals, endpoint)
+
+	continuedData := writePatternToBlockDevice(c, endpoint, 'R', 4096, 4096)
+	readAndVerifyBlockDevicePattern(c, endpoint, continuedData, 4096)
 }
 
 func (s *TestSuite) TestSPDKEngineReplicaAddWithoutEngineFrontendInfo(c *C) {

--- a/pkg/spdk_test.go
+++ b/pkg/spdk_test.go
@@ -4783,7 +4783,7 @@ func (s *TestSuite) TestSPDKEngineFrontendReplicaAddErrorHandling(c *C) {
 	// ReplicaRebuildingDstStart fails deterministically without a transport timeout.
 	missingReplicaName := fmt.Sprintf("%s-replica-missing", volumeName)
 	missingReplicaAddress := replica2Address
-	err = spdkCli.EngineFrontendReplicaAdd(engineFrontendName, missingReplicaName, missingReplicaAddress, defaultTestFastSync, "", "", "")
+	err = spdkCli.EngineFrontendReplicaAdd(engineFrontendName, missingReplicaName, missingReplicaAddress, defaultTestFastSync, nil)
 	c.Assert(err, NotNil)
 
 	engine, err = spdkCli.EngineGet(engineName)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13673

#### What this PR does / why we need it:

Keep synchronous V2 replica-add setup failures scoped to the destination replica.

`replicaAddStart()` separates fatal engine failures from replica-local setup failures. Its frontend wrapper returns the inner work error, but `ReplicaAdd()` also promoted that returned setup error to `engineErr` because it checked the still-nil named return `err`. A destination connection or `ReplicaRebuildingDstStart` failure could therefore fault the entire engine and disrupt the frontend despite healthy `RW` replicas remaining.

Remove that promotion. Fatal errors remain captured through `startEngineErr`, while setup failures still return to the caller and mark the destination replica `ERR`.

Extend the existing real SPDK frontend replica-add error test with a synchronous destination-start failure. The test verifies that:

- the replica-add call returns an error;
- the failed destination becomes `ERR`;
- existing replicas remain `RW`;
- engine and frontend remain `Running` with empty error messages; and
- endpoint I/O continues.

#### Special notes for your reviewer:

The production suspend/resume wrapper returns only `workErr`. Frontend connection, suspend, and resume failures are logged and handled separately, so no wrapper-specific fatal error is lost by this change.

The regression uses a reachable SPDK service with a missing destination replica name. This deterministically exercises the same synchronous `ReplicaRebuildingDstStart` classification path without waiting for a transport timeout.

The secondary stale NVMe-controller recovery timing observed after the incident is intentionally out of scope.

#### Additional documentation or context

Local validation:

- Linux/amd64 cross-compilation of all packages
- `GOOS=linux GOARCH=amd64 go vet ./...`
- `GOOS=linux GOARCH=amd64 golangci-lint run --timeout=5m`

The SPDK integration test requires the repository privileged Linux test environment and is covered by upstream CI.
