### PR TITLE
feat(replica): drive the host-ACL restriction from the ReplicaCreate request

### DIFF
--- a/pkg/client/client_replica.go
+++ b/pkg/client/client_replica.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ReplicaCreate creates and starts a replica in the specified lvstore.
-func (c *SPDKClient) ReplicaCreate(name, lvsName, lvsUUID string, specSize uint64, portCount int32, backingImageName string) (*api.Replica, error) {
+func (c *SPDKClient) ReplicaCreate(name, lvsName, lvsUUID string, specSize uint64, portCount int32, backingImageName string, restrictHostACL bool) (*api.Replica, error) {
 	if name == "" || lvsName == "" || lvsUUID == "" {
 		return nil, fmt.Errorf("failed to start SPDK replica: missing required parameters")
 	}
@@ -31,6 +31,7 @@ func (c *SPDKClient) ReplicaCreate(name, lvsName, lvsUUID string, specSize uint6
 		SpecSize:         specSize,
 		PortCount:        portCount,
 		BackingImageName: backingImageName,
+		RestrictHostAcl:  restrictHostACL,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start SPDK replica")

--- a/pkg/linked_clone_test.go
+++ b/pkg/linked_clone_test.go
@@ -68,7 +68,7 @@ func (lce *linkedCloneTestEnv) setupSrcReplicaWithSnapshot(c *C) func() {
 	spdkCli := lce.spdkCli
 
 	_, err := spdkCli.ReplicaCreate(lce.srcReplicaName, defaultTestDiskName, lce.disk.Uuid,
-		defaultTestLvolSize, defaultTestReplicaPortCount, "")
+		defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 
 	err = spdkCli.ReplicaSnapshotCreate(lce.srcReplicaName, lce.snapshotName,
@@ -89,7 +89,7 @@ func (lce *linkedCloneTestEnv) setupSrcReplicaWithSnapshot(c *C) func() {
 // createDstReplica creates the destination (clone) replica.
 func (lce *linkedCloneTestEnv) createDstReplica(c *C) {
 	_, err := lce.spdkCli.ReplicaCreate(lce.dstReplicaName, defaultTestDiskName,
-		lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+		lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 }
 
@@ -366,7 +366,7 @@ func (lce *linkedCloneTestEnv) createNDstReplicas(c *C, n int) []string {
 		suffix := strings.ReplaceAll(util.UUID(), "-", "")[:6]
 		name := fmt.Sprintf("%s-dst-%d-%s", lce.volumeName, i, suffix)
 		_, err := lce.spdkCli.ReplicaCreate(name, defaultTestDiskName,
-			lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+			lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 		c.Assert(err, IsNil)
 		names[i] = name
 	}
@@ -564,7 +564,7 @@ func (s *TestSuite) TestLinkedCloneRebuildNewReplica(c *C) {
 		// Create a brand-new dst replica 2 (no prior clone data).
 		dst2Name := fmt.Sprintf("%s-dst2", lce.volumeName)
 		_, err = lce.spdkCli.ReplicaCreate(dst2Name, defaultTestDiskName,
-			lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+			lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 		c.Assert(err, IsNil)
 		defer func() { _ = lce.spdkCli.ReplicaDelete(dst2Name, true) }()
 
@@ -628,7 +628,7 @@ func (s *TestSuite) TestLinkedCloneRebuildReusedFailedReplica(c *C) {
 		dst2Suffix := strings.ReplaceAll(util.UUID(), "-", "")[:6]
 		dst2Name := fmt.Sprintf("%s-dst2-%s", lce.volumeName, dst2Suffix)
 		_, err = lce.spdkCli.ReplicaCreate(dst2Name, defaultTestDiskName,
-			lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+			lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 		c.Assert(err, IsNil)
 		defer func() { _ = lce.spdkCli.ReplicaDelete(dst2Name, true) }()
 		err = lce.spdkCli.ReplicaSnapshotCloneDstStart(
@@ -731,12 +731,12 @@ func (s *TestSuite) TestLinkedCloneRebuildAfterExpansion(c *C) {
 		srcReplica2Name := fmt.Sprintf("%s-src-r2", lce.volumeName)
 
 		_, err = lce.spdkCli.ReplicaCreate(lce.srcReplicaName, defaultTestDiskName,
-			lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+			lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 		c.Assert(err, IsNil)
 		defer func() { _ = lce.spdkCli.ReplicaDelete(lce.srcReplicaName, true) }()
 
 		_, err = lce.spdkCli.ReplicaCreate(srcReplica2Name, defaultTestDiskName,
-			lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+			lce.disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 		c.Assert(err, IsNil)
 		defer func() { _ = lce.spdkCli.ReplicaDelete(srcReplica2Name, true) }()
 
@@ -843,7 +843,7 @@ func (s *TestSuite) TestLinkedCloneRebuildAfterExpansion(c *C) {
 
 		dst2Name := fmt.Sprintf("%s-expand-dst2", lce.volumeName)
 		_, err = lce.spdkCli.ReplicaCreate(dst2Name, defaultTestDiskName,
-			lce.disk.Uuid, expandedSize, defaultTestReplicaPortCount, "")
+			lce.disk.Uuid, expandedSize, defaultTestReplicaPortCount, "", true)
 		c.Assert(err, IsNil)
 		defer func() { _ = lce.spdkCli.ReplicaDelete(dst2Name, true) }()
 

--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -85,6 +85,11 @@ type Replica struct {
 	IsExposed               bool
 	SnapshotChecksumEnabled bool
 
+	// restrictHostACL limits every subsystem this replica exposes to the
+	// internal host NQN. Follows the latest ReplicaCreate request; false
+	// keeps the any-host ACL.
+	restrictHostACL bool
+
 	// SnapshotLvolHashStatusMap map[<snapshot lvol name>]LvolHashStatus.
 	SnapshotLvolHashStatusMap sync.Map
 
@@ -360,6 +365,24 @@ func (r *Replica) GetAddress() string {
 	r.RLock()
 	defer r.RUnlock()
 	return net.JoinHostPort(r.IP, strconv.Itoa(int(r.PortStart)))
+}
+
+// exposeAllowedHosts returns the host NQN allowlist for every subsystem this
+// replica exposes: the internal host NQN when the restriction is requested,
+// or nil to keep the subsystem open to any host.
+func (r *Replica) exposeAllowedHosts() []string {
+	if r.restrictHostACL {
+		return []string{helpertypes.InternalHostNQN}
+	}
+	return nil
+}
+
+// SetRestrictHostACL applies the host-ACL decision carried by a ReplicaCreate
+// request.
+func (r *Replica) SetRestrictHostACL(restrict bool) {
+	r.Lock()
+	defer r.Unlock()
+	r.restrictHostACL = restrict
 }
 
 func (r *Replica) prepareIPAndPorts(portCount int32, superiorPortAllocator *commonbitmap.Bitmap) error {
@@ -1513,7 +1536,7 @@ func (r *Replica) Create(spdkClient *spdkclient.Client, portCount int32, superio
 	}
 
 	if err := spdkClient.StartExposeBdev(r.Nqn, r.Head.UUID, generateNGUID(r.Name), r.IP, strconv.Itoa(int(r.PortStart)),
-		helpertypes.InternalHostNQN); err != nil {
+		r.exposeAllowedHosts()...); err != nil {
 		return nil, err
 	}
 
@@ -1806,7 +1829,7 @@ func (r *Replica) Expand(spdkClient *spdkclient.Client, size uint64) error {
 	// If we had previously exposed the bdev, we must re-expose it after the resize.
 	if reExposeBdev {
 		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.Name), r.Head.UUID, generateNGUID(r.Name), r.IP, strconv.Itoa(int(r.PortStart)),
-			helpertypes.InternalHostNQN); err != nil {
+			r.exposeAllowedHosts()...); err != nil {
 			return errors.Wrapf(err, "failed to start expose replica %v after expansion", r.Name)
 		}
 		r.IsExposed = true
@@ -2167,7 +2190,7 @@ func (r *Replica) SnapshotRevert(spdkClient *spdkclient.Client, snapshotName str
 		r.IsExposed = false
 
 		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.Name), headLvolUUID, generateNGUID(r.Name), r.IP, strconv.Itoa(int(r.PortStart)),
-			helpertypes.InternalHostNQN); err != nil {
+			r.exposeAllowedHosts()...); err != nil {
 			return nil, err
 		}
 		r.IsExposed = true
@@ -2532,7 +2555,7 @@ func (r *Replica) SnapshotCloneDstStart(spdkClient *spdkclient.Client, snapshotN
 
 	if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.snapshotCloningDstCache.cloningLvol.Name),
 		r.snapshotCloningDstCache.cloningLvol.UUID, generateNGUID(r.snapshotCloningDstCache.cloningLvol.Name), r.IP,
-		strconv.Itoa(int(r.snapshotCloningDstCache.cloningPort)), helpertypes.InternalHostNQN); err != nil {
+		strconv.Itoa(int(r.snapshotCloningDstCache.cloningPort)), r.exposeAllowedHosts()...); err != nil {
 		return err
 	}
 	dstCloningLvolAddress := net.JoinHostPort(r.IP, strconv.Itoa(int(r.snapshotCloningDstCache.cloningPort)))
@@ -3289,7 +3312,7 @@ func (r *Replica) RebuildingSrcStart(spdkClient *spdkclient.Client, dstReplicaNa
 		return "", err
 	}
 	if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(snapLvol.Name), snapLvol.UUID, generateNGUID(snapLvol.Name), r.IP, strconv.Itoa(int(port)),
-		helpertypes.InternalHostNQN); err != nil {
+		r.exposeAllowedHosts()...); err != nil {
 		return "", err
 	}
 	exposedSnapshotLvolAddress = net.JoinHostPort(r.IP, strconv.Itoa(int(port)))
@@ -3869,7 +3892,7 @@ func (r *Replica) RebuildingDstStart(spdkClient *spdkclient.Client, srcReplicaNa
 	r.ActiveChain = append(r.ActiveChain, r.Head)
 
 	if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.Name), r.Head.UUID, generateNGUID(r.Name), r.IP, strconv.Itoa(int(r.PortStart)),
-		helpertypes.InternalHostNQN); err != nil {
+		r.exposeAllowedHosts()...); err != nil {
 		return "", err
 	}
 	r.IsExposed = true
@@ -4402,7 +4425,7 @@ func (r *Replica) rebuildingDstShallowCopyPrepare(spdkClient *spdkclient.Client,
 	if r.rebuildingDstCache.rebuildingPort != 0 {
 		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.rebuildingDstCache.rebuildingLvol.Name), r.rebuildingDstCache.rebuildingLvol.UUID,
 			generateNGUID(r.rebuildingDstCache.rebuildingLvol.Name), r.IP, strconv.Itoa(int(r.rebuildingDstCache.rebuildingPort)),
-			helpertypes.InternalHostNQN); err != nil {
+			r.exposeAllowedHosts()...); err != nil {
 			return "", false, err
 		}
 		dstRebuildingLvolAddress = net.JoinHostPort(r.IP, strconv.Itoa(int(r.rebuildingDstCache.rebuildingPort)))

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -529,6 +529,9 @@ func (s *Server) rebuildCachedLvolObjects(state *verifyState) error {
 			lvsUUID := bdevLvol.DriverSpecific.Lvol.LvolStoreUUID
 			specSize := bdevLvol.NumBlocks * uint64(bdevLvol.BlockSize)
 			actualSize := bdevLvol.DriverSpecific.Lvol.NumAllocatedClusters * uint64(defaultClusterSize)
+			// Replicas reconstructed from existing lvols fall back to the
+			// any-host ACL: the creation-time flag is not persisted, and the
+			// restriction resumes on the next ReplicaCreate.
 			state.replicaMap[lvolName] = NewReplica(s.ctx, lvolName, lvsUUIDNameMap[lvsUUID], lvsUUID, specSize, true, s.updateChs[types.InstanceTypeReplica], s.newServiceClient)
 			state.replicaMapForSync[lvolName] = state.replicaMap[lvolName]
 			logrus.Infof("Detected one possible existing replica %s(%s) with disk %s(%s), spec size %d, actual size %d", bdevLvol.Aliases[0], bdevLvol.UUID, lvsUUIDNameMap[lvsUUID], lvsUUID, specSize, actualSize)

--- a/pkg/spdk/server_replica.go
+++ b/pkg/spdk/server_replica.go
@@ -48,6 +48,11 @@ func (s *Server) ReplicaCreate(ctx context.Context, req *spdkrpc.ReplicaCreateRe
 		return nil, err
 	}
 
+	// A replica reconstructed from an on-disk lvol during startup, or reused
+	// from the replica map, was registered before this request existed; adopt
+	// the host-ACL decision carried by the latest create request.
+	r.SetRestrictHostACL(req.RestrictHostAcl)
+
 	defer func() {
 		// Always update the replica map
 		s.Lock()

--- a/pkg/spdk_test.go
+++ b/pkg/spdk_test.go
@@ -400,12 +400,12 @@ func (s *TestSuite) TestReplicaCreateWithStateChecks(c *C) {
 	}()
 
 	// Pending -> first create should succeed
-	replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	c.Assert(replica.State, Equals, types.InstanceStateRunning)
 
 	// Running -> create again should return AlreadyExists
-	_, err = spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	_, err = spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, NotNil)
 	rootErr := errors.UnwrapAll(err)
 	st, ok := grpcstatus.FromError(rootErr)
@@ -421,7 +421,7 @@ func (s *TestSuite) TestReplicaCreateWithStateChecks(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(replica.State, Equals, types.InstanceStateStopped)
 
-	replica, err = spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica, err = spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	c.Assert(replica.State, Equals, types.InstanceStateRunning)
 }
@@ -661,7 +661,7 @@ func (s *TestSuite) TestSPDKEngineAndEngineFrontendCreateAndDeleteWithDifferentF
 			}()
 
 			for _, replicaName := range replicaNames {
-				replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+				replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 				c.Assert(err, IsNil)
 				c.Assert(replica.LvsName, Equals, defaultTestDiskName)
 				c.Assert(replica.LvsUUID, Equals, disk.Uuid)
@@ -794,7 +794,7 @@ func (s *TestSuite) TestSPDKEngineFrontendSuspendAndResume(c *C) {
 
 	// Create replicas
 	for _, replicaName := range replicaNames {
-		replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+		replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 		c.Assert(err, IsNil)
 		c.Assert(replica.LvsName, Equals, defaultTestDiskName)
 		c.Assert(replica.LvsUUID, Equals, disk.Uuid)
@@ -1023,7 +1023,7 @@ func (s *TestSuite) TestSPDKEngineFrontendExpand(c *C) {
 
 	// Create replicas
 	for _, replicaName := range replicaNames {
-		replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+		replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 		c.Assert(err, IsNil)
 		c.Assert(replica.LvsName, Equals, defaultTestDiskName)
 		c.Assert(replica.LvsUUID, Equals, disk.Uuid)
@@ -1175,7 +1175,7 @@ func (s *TestSuite) TestSPDKEngineSnapshotCreateAndDelete(c *C) {
 	}()
 
 	for _, replicaName := range replicaNames {
-		replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+		replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 		c.Assert(err, IsNil)
 		replicas[replicaName] = replica
 	}
@@ -1328,7 +1328,7 @@ func (s *TestSuite) TestSPDKEngineFrontendSnapshotRevert(c *C) {
 			}()
 
 			for _, replicaName := range replicaNames {
-				replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+				replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 				c.Assert(err, IsNil)
 				replicas[replicaName] = replica
 			}
@@ -1771,7 +1771,7 @@ func (s *TestSuite) TestSPDKEngineCreateWithSalvageRequested(c *C) {
 	}()
 
 	for _, replicaName := range replicaNames {
-		replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+		replica, err := spdkCli.ReplicaCreate(replicaName, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 		c.Assert(err, IsNil)
 		replicas[replicaName] = replica
 	}
@@ -1945,7 +1945,7 @@ func (s *TestSuite) TestSPDKMultipleThread(c *C) {
 				wg.Done()
 			}()
 
-			replica1, err := spdkCli.ReplicaCreate(replicaName1, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+			replica1, err := spdkCli.ReplicaCreate(replicaName1, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 			c.Assert(err, IsNil)
 			c.Assert(replica1.LvsName, Equals, defaultTestDiskName)
 			c.Assert(replica1.LvsUUID, Equals, disk.Uuid)
@@ -1955,7 +1955,7 @@ func (s *TestSuite) TestSPDKMultipleThread(c *C) {
 			c.Assert(replica1.Head, NotNil)
 			c.Assert(replica1.Head.CreationTime, Not(Equals), "")
 			c.Assert(replica1.Head.Parent, Equals, "")
-			replica2, err := spdkCli.ReplicaCreate(replicaName2, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+			replica2, err := spdkCli.ReplicaCreate(replicaName2, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 			c.Assert(err, IsNil)
 			c.Assert(replica2.LvsName, Equals, defaultTestDiskName)
 			c.Assert(replica2.LvsUUID, Equals, disk.Uuid)
@@ -2061,11 +2061,11 @@ func (s *TestSuite) TestSPDKMultipleThread(c *C) {
 			c.Assert(replica2.PortStart, Equals, int32(0))
 			c.Assert(replica2.PortEnd, Equals, int32(0))
 
-			replica1, err = spdkCli.ReplicaCreate(replicaName1, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+			replica1, err = spdkCli.ReplicaCreate(replicaName1, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 			c.Assert(err, IsNil)
 			c.Assert(replica1.ErrorMsg, Equals, "")
 			c.Assert(replica1.State, Equals, types.InstanceStateRunning)
-			replica2, err = spdkCli.ReplicaCreate(replicaName2, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+			replica2, err = spdkCli.ReplicaCreate(replicaName2, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 			c.Assert(err, IsNil)
 			c.Assert(replica2.ErrorMsg, Equals, "")
 			c.Assert(replica2.State, Equals, types.InstanceStateRunning)
@@ -2117,7 +2117,7 @@ func (s *TestSuite) TestSPDKMultipleThread(c *C) {
 
 			// Start testing online rebuilding
 			// Launch a new replica then ask the engine to rebuild it
-			replica3, err := spdkCli.ReplicaCreate(replicaName3, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+			replica3, err := spdkCli.ReplicaCreate(replicaName3, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 			c.Assert(err, IsNil)
 			c.Assert(replica3.LvsName, Equals, defaultTestDiskName)
 			c.Assert(replica3.LvsUUID, Equals, disk.Uuid)
@@ -2332,7 +2332,7 @@ func (s *TestSuite) spdkMultipleThreadSnapshotOpsAndRebuilding(c *C, withBacking
 			if withBackingImage {
 				backingImageName = bi.Name
 			}
-			replica1, err := spdkCli.ReplicaCreate(replicaName1, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, backingImageName)
+			replica1, err := spdkCli.ReplicaCreate(replicaName1, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, backingImageName, true)
 
 			c.Assert(err, IsNil)
 			c.Assert(replica1.LvsName, Equals, defaultTestDiskName)
@@ -2340,7 +2340,7 @@ func (s *TestSuite) spdkMultipleThreadSnapshotOpsAndRebuilding(c *C, withBacking
 			c.Assert(replica1.ErrorMsg, Equals, "")
 			c.Assert(replica1.State, Equals, types.InstanceStateRunning)
 			c.Assert(replica1.PortStart, Not(Equals), int32(0))
-			replica2, err := spdkCli.ReplicaCreate(replicaName2, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, backingImageName)
+			replica2, err := spdkCli.ReplicaCreate(replicaName2, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, backingImageName, true)
 			c.Assert(err, IsNil)
 			c.Assert(replica2.LvsName, Equals, defaultTestDiskName)
 			c.Assert(replica2.LvsUUID, Equals, disk.Uuid)
@@ -2915,7 +2915,7 @@ func (s *TestSuite) spdkMultipleThreadSnapshotOpsAndRebuilding(c *C, withBacking
 			c.Assert(engine.ReplicaAddressMap, DeepEquals, replicaAddressMap)
 			c.Assert(engine.ReplicaModeMap, DeepEquals, map[string]types.Mode{replicaName2: types.ModeRW})
 			// Launch the 1st rebuilding replica as the replacement of the crashed replica1
-			replica3, err := spdkCli.ReplicaCreate(replicaName3, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, backingImageName)
+			replica3, err := spdkCli.ReplicaCreate(replicaName3, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, backingImageName, true)
 			c.Assert(err, IsNil)
 			c.Assert(replica3.LvsName, Equals, defaultTestDiskName)
 			c.Assert(replica3.LvsUUID, Equals, disk.Uuid)
@@ -3013,7 +3013,7 @@ func (s *TestSuite) spdkMultipleThreadSnapshotOpsAndRebuilding(c *C, withBacking
 			c.Assert(engine.ReplicaAddressMap, DeepEquals, replicaAddressMap)
 			c.Assert(engine.ReplicaModeMap, DeepEquals, map[string]types.Mode{replicaName3: types.ModeRW})
 			// Launch the 2nd rebuilding replica as the replacement of the crashed replica2
-			replica4, err := spdkCli.ReplicaCreate(replicaName4, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, backingImageName)
+			replica4, err := spdkCli.ReplicaCreate(replicaName4, defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, backingImageName, true)
 			c.Assert(err, IsNil)
 			c.Assert(replica4.LvsName, Equals, defaultTestDiskName)
 			c.Assert(replica4.LvsUUID, Equals, disk.Uuid)
@@ -3411,14 +3411,14 @@ func (s *TestSuite) spdkMultipleThreadFastRebuilding(c *C, withBackingImage bool
 			vol.replicaName1 = fmt.Sprintf("%s-replica-1", vol.volumeName)
 			vol.replicaName2 = fmt.Sprintf("%s-replica-2", vol.volumeName)
 
-			replica1, err := spdkCli.ReplicaCreate(vol.replicaName1, defaultTestDiskName, disk.Uuid, defaultTestLargeLvolSize, defaultTestReplicaPortCount, backingImageName)
+			replica1, err := spdkCli.ReplicaCreate(vol.replicaName1, defaultTestDiskName, disk.Uuid, defaultTestLargeLvolSize, defaultTestReplicaPortCount, backingImageName, true)
 			if err != nil {
 				createErrs[idx] = fmt.Errorf("failed to create replica1 for vol %d: %w", idx, err)
 				return
 			}
 			vol.replica1 = replica1
 
-			replica2, err := spdkCli.ReplicaCreate(vol.replicaName2, defaultTestDiskName, disk.Uuid, defaultTestLargeLvolSize, defaultTestReplicaPortCount, backingImageName)
+			replica2, err := spdkCli.ReplicaCreate(vol.replicaName2, defaultTestDiskName, disk.Uuid, defaultTestLargeLvolSize, defaultTestReplicaPortCount, backingImageName, true)
 			if err != nil {
 				createErrs[idx] = fmt.Errorf("failed to create replica2 for vol %d: %w", idx, err)
 				return
@@ -3708,7 +3708,7 @@ func (s *TestSuite) spdkMultipleThreadFastRebuilding(c *C, withBackingImage bool
 			c.Assert(engine.ReplicaAddressMap, DeepEquals, replicaAddressMap)
 			c.Assert(engine.ReplicaModeMap, DeepEquals, map[string]types.Mode{replicaName2: types.ModeRW})
 
-			replica1, err = spdkCli.ReplicaCreate(replicaName1, defaultTestDiskName, disk.Uuid, defaultTestLargeLvolSize, defaultTestReplicaPortCount, backingImageName)
+			replica1, err = spdkCli.ReplicaCreate(replicaName1, defaultTestDiskName, disk.Uuid, defaultTestLargeLvolSize, defaultTestReplicaPortCount, backingImageName, true)
 			c.Assert(err, IsNil)
 			c.Assert(replica1.LvsName, Equals, defaultTestDiskName)
 			c.Assert(replica1.LvsUUID, Equals, disk.Uuid)
@@ -4387,7 +4387,7 @@ func (s *TestSuite) TestSPDKEngineFrontendReplicaAdd(c *C) {
 	}()
 
 	// 1. Create first replica
-	replica, err := spdkCli.ReplicaCreate(replicaNames[0], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica, err := spdkCli.ReplicaCreate(replicaNames[0], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	replicas[replicaNames[0]] = replica
 
@@ -4419,7 +4419,7 @@ func (s *TestSuite) TestSPDKEngineFrontendReplicaAdd(c *C) {
 	dataB := writePatternToBlockDevice(c, endpoint, 'B', 4096, 4096)
 
 	// 7. Add Second Replica
-	replica2, err := spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica2, err := spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	replicas[replicaNames[1]] = replica2
 	replica2Address := net.JoinHostPort(ip, strconv.Itoa(int(replica2.PortStart)))
@@ -4532,7 +4532,7 @@ func (s *TestSuite) TestSPDKEngineFrontendReplicaAddErrorHandling(c *C) {
 	}()
 
 	// 1. Create first replica
-	replica, err := spdkCli.ReplicaCreate(replicaNames[0], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica, err := spdkCli.ReplicaCreate(replicaNames[0], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	replicas[replicaNames[0]] = replica
 
@@ -4556,7 +4556,7 @@ func (s *TestSuite) TestSPDKEngineFrontendReplicaAddErrorHandling(c *C) {
 	c.Assert(internalEngine, NotNil)
 
 	// 4. Create Second Replica
-	replica2, err := spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica2, err := spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	replicas[replicaNames[1]] = replica2
 	replica2Address := net.JoinHostPort(ip, strconv.Itoa(int(replica2.PortStart)))
@@ -4608,7 +4608,7 @@ func (s *TestSuite) TestSPDKEngineFrontendReplicaAddErrorHandling(c *C) {
 	err = spdkCli.ReplicaDelete(replicaNames[1], true)
 	c.Assert(err, IsNil)
 
-	replica2, err = spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica2, err = spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	replica2Address = net.JoinHostPort(ip, strconv.Itoa(int(replica2.PortStart)))
 
@@ -4649,7 +4649,7 @@ func (s *TestSuite) TestSPDKEngineFrontendReplicaAddErrorHandling(c *C) {
 	err = spdkCli.ReplicaDelete(replicaNames[1], true)
 	c.Assert(err, IsNil)
 
-	replica2, err = spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica2, err = spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	replica2Address = net.JoinHostPort(ip, strconv.Itoa(int(replica2.PortStart)))
 
@@ -4681,7 +4681,7 @@ func (s *TestSuite) TestSPDKEngineFrontendReplicaAddErrorHandling(c *C) {
 	// so resources are already cleaned up and ReplicaDelete won't hang.
 	err = spdkCli.ReplicaDelete(replicaNames[1], true)
 	c.Assert(err, IsNil)
-	replica2, err = spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica2, err = spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	replica2Address = net.JoinHostPort(ip, strconv.Itoa(int(replica2.PortStart)))
 
@@ -4740,7 +4740,7 @@ func (s *TestSuite) TestSPDKEngineFrontendReplicaAddErrorHandling(c *C) {
 	err = spdkCli.ReplicaDelete(replicaNames[1], true)
 	c.Assert(err, IsNil)
 
-	replica2, err = spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica2, err = spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	replica2Address = net.JoinHostPort(ip, strconv.Itoa(int(replica2.PortStart)))
 	replicas[replicaNames[1]] = replica2
@@ -4864,7 +4864,7 @@ func (s *TestSuite) TestSPDKEngineReplicaAddWithoutEngineFrontendInfo(c *C) {
 		}
 	}()
 
-	replica1, err := spdkCli.ReplicaCreate(replicaNames[0], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica1, err := spdkCli.ReplicaCreate(replicaNames[0], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	replicas[replicaNames[0]] = replica1
 	replicaAddressMap := map[string]string{
@@ -4874,7 +4874,7 @@ func (s *TestSuite) TestSPDKEngineReplicaAddWithoutEngineFrontendInfo(c *C) {
 	_, err = spdkCli.EngineCreate(engineName, volumeName, types.FrontendEmpty, defaultTestLvolSize, replicaAddressMap, 1, false, 0, spdkrpc.DataLayoutType_DATA_LAYOUT_TYPE_REPLICATED)
 	c.Assert(err, IsNil)
 
-	replica2, err := spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "")
+	replica2, err := spdkCli.ReplicaCreate(replicaNames[1], defaultTestDiskName, disk.Uuid, defaultTestLvolSize, defaultTestReplicaPortCount, "", true)
 	c.Assert(err, IsNil)
 	replicas[replicaNames[1]] = replica2
 	replica2Address := net.JoinHostPort(ip, strconv.Itoa(int(replica2.PortStart)))


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13699

#### What this PR does / why we need it:

Replica exposures follow the host-ACL flag carried by `ReplicaCreateRequest`, applied on every create including replicas reconstructed by the startup scan. Shard and shard group exposures keep the unconditional restriction.

#### Special notes for your reviewer:

Depends on the longhorn/types PR (go.mod bump after it merges). Merged alone this reverts replica exposures to any-host — ships together with the instance-manager and manager counterparts.

#### Additional documentation or context

`None`
