### PR TITLE
feat(spdk): thread NVMe-oF transport type through engine/replica create

### DIFF
--- a/pkg/client/client_engine.go
+++ b/pkg/client/client_engine.go
@@ -20,7 +20,7 @@ import (
 // DATA_LAYOUT_TYPE_SHARDED constructs a single shardGroupBackend (EC).
 // Without forwarding this field, callers would default to the proto3 zero
 // value (REPLICATED), and EC volumes would be silently miscreated as RAID1.
-func (c *SPDKClient) EngineCreate(name, volumeName, frontend string, specSize uint64, replicaAddressMap map[string]string, portCount int32, salvageRequested bool, snapshotMaxCount int32, dataLayoutType spdkrpc.DataLayoutType, transportType spdkrpc.DataEngineTransport) (*api.Engine, error) {
+func (c *SPDKClient) EngineCreate(name, volumeName, frontend string, specSize uint64, replicaAddressMap map[string]string, portCount int32, salvageRequested bool, snapshotMaxCount int32, dataLayoutType spdkrpc.DataLayoutType, transportType spdkrpc.TransportType) (*api.Engine, error) {
 	if name == "" {
 		return nil, fmt.Errorf("failed to start engine: missing required parameter name")
 	}
@@ -45,7 +45,7 @@ func (c *SPDKClient) EngineCreate(name, volumeName, frontend string, specSize ui
 		SalvageRequested:    salvageRequested,
 		SnapshotMaxCount:    snapshotMaxCount,
 		DataLayoutType:      dataLayoutType,
-		DataEngineTransport: transportType,
+		TransportType: transportType,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start engine")

--- a/pkg/client/client_engine.go
+++ b/pkg/client/client_engine.go
@@ -20,7 +20,7 @@ import (
 // DATA_LAYOUT_TYPE_SHARDED constructs a single shardGroupBackend (EC).
 // Without forwarding this field, callers would default to the proto3 zero
 // value (REPLICATED), and EC volumes would be silently miscreated as RAID1.
-func (c *SPDKClient) EngineCreate(name, volumeName, frontend string, specSize uint64, replicaAddressMap map[string]string, portCount int32, salvageRequested bool, snapshotMaxCount int32, dataLayoutType spdkrpc.DataLayoutType) (*api.Engine, error) {
+func (c *SPDKClient) EngineCreate(name, volumeName, frontend string, specSize uint64, replicaAddressMap map[string]string, portCount int32, salvageRequested bool, snapshotMaxCount int32, dataLayoutType spdkrpc.DataLayoutType, transportType spdkrpc.DataEngineTransport) (*api.Engine, error) {
 	if name == "" {
 		return nil, fmt.Errorf("failed to start engine: missing required parameter name")
 	}
@@ -36,15 +36,16 @@ func (c *SPDKClient) EngineCreate(name, volumeName, frontend string, specSize ui
 	defer cancel()
 
 	resp, err := client.EngineCreate(ctx, &spdkrpc.EngineCreateRequest{
-		Name:              name,
-		VolumeName:        volumeName,
-		Frontend:          frontend,
-		SpecSize:          specSize,
-		ReplicaAddressMap: replicaAddressMap,
-		PortCount:         portCount,
-		SalvageRequested:  salvageRequested,
-		SnapshotMaxCount:  snapshotMaxCount,
-		DataLayoutType:    dataLayoutType,
+		Name:                name,
+		VolumeName:          volumeName,
+		Frontend:            frontend,
+		SpecSize:            specSize,
+		ReplicaAddressMap:   replicaAddressMap,
+		PortCount:           portCount,
+		SalvageRequested:    salvageRequested,
+		SnapshotMaxCount:    snapshotMaxCount,
+		DataLayoutType:      dataLayoutType,
+		DataEngineTransport: transportType,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start engine")

--- a/pkg/client/client_replica.go
+++ b/pkg/client/client_replica.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ReplicaCreate creates and starts a replica in the specified lvstore.
-func (c *SPDKClient) ReplicaCreate(name, lvsName, lvsUUID string, specSize uint64, portCount int32, backingImageName string, transportType spdkrpc.DataEngineTransport) (*api.Replica, error) {
+func (c *SPDKClient) ReplicaCreate(name, lvsName, lvsUUID string, specSize uint64, portCount int32, backingImageName string, transportType spdkrpc.TransportType) (*api.Replica, error) {
 	if name == "" || lvsName == "" || lvsUUID == "" {
 		return nil, fmt.Errorf("failed to start SPDK replica: missing required parameters")
 	}
@@ -31,7 +31,7 @@ func (c *SPDKClient) ReplicaCreate(name, lvsName, lvsUUID string, specSize uint6
 		SpecSize:            specSize,
 		PortCount:           portCount,
 		BackingImageName:    backingImageName,
-		DataEngineTransport: transportType,
+		TransportType: transportType,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start SPDK replica")

--- a/pkg/client/client_replica.go
+++ b/pkg/client/client_replica.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ReplicaCreate creates and starts a replica in the specified lvstore.
-func (c *SPDKClient) ReplicaCreate(name, lvsName, lvsUUID string, specSize uint64, portCount int32, backingImageName string) (*api.Replica, error) {
+func (c *SPDKClient) ReplicaCreate(name, lvsName, lvsUUID string, specSize uint64, portCount int32, backingImageName string, transportType spdkrpc.DataEngineTransport) (*api.Replica, error) {
 	if name == "" || lvsName == "" || lvsUUID == "" {
 		return nil, fmt.Errorf("failed to start SPDK replica: missing required parameters")
 	}
@@ -25,12 +25,13 @@ func (c *SPDKClient) ReplicaCreate(name, lvsName, lvsUUID string, specSize uint6
 	defer cancel()
 
 	resp, err := client.ReplicaCreate(ctx, &spdkrpc.ReplicaCreateRequest{
-		Name:             name,
-		LvsName:          lvsName,
-		LvsUuid:          lvsUUID,
-		SpecSize:         specSize,
-		PortCount:        portCount,
-		BackingImageName: backingImageName,
+		Name:                name,
+		LvsName:             lvsName,
+		LvsUuid:             lvsUUID,
+		SpecSize:            specSize,
+		PortCount:           portCount,
+		BackingImageName:    backingImageName,
+		DataEngineTransport: transportType,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start SPDK replica")

--- a/pkg/spdk/backend_test.go
+++ b/pkg/spdk/backend_test.go
@@ -3,6 +3,7 @@ package spdk
 import (
 	"fmt"
 
+	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
 	"github.com/longhorn/types/pkg/generated/spdkrpc"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -84,7 +85,7 @@ func (s *TestSuite) TestIsShardedEngine(c *C) {
 
 	for name, tc := range testCases {
 		fmt.Println("Testing isShardedEngine:", name)
-		e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+		e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 		e.backends = tc.backends
 		c.Assert(isShardedEngine(e), Equals, tc.expected, Commentf("case %q", name))
 	}

--- a/pkg/spdk/backup_restore_test.go
+++ b/pkg/spdk/backup_restore_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
+
 	"github.com/longhorn/longhorn-spdk-engine/pkg/api"
 	lhtypes "github.com/longhorn/longhorn-spdk-engine/pkg/types"
 
@@ -27,7 +29,7 @@ func newTestReplicaBackend(name, address string, mode lhtypes.Mode) *replicaBack
 func (s *TestSuite) TestEnsureReplicaModeForInfoUpdateRWQualifies(c *C) {
 	fmt.Println("Testing ensureReplicaModeForInfoUpdate: RW mode qualifies for info update")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	rs := newTestReplicaBackend("replica-1", "10.0.0.1:1234", lhtypes.ModeRW)
 
 	ok := e.ensureReplicaModeForInfoUpdate("replica-1", rs)
@@ -39,7 +41,7 @@ func (s *TestSuite) TestEnsureReplicaModeForInfoUpdateRWQualifies(c *C) {
 func (s *TestSuite) TestEnsureReplicaModeForInfoUpdateWOQualifies(c *C) {
 	fmt.Println("Testing ensureReplicaModeForInfoUpdate: WO mode qualifies for info update")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	rs := newTestReplicaBackend("replica-1", "10.0.0.1:1234", lhtypes.ModeWO)
 
 	ok := e.ensureReplicaModeForInfoUpdate("replica-1", rs)
@@ -51,7 +53,7 @@ func (s *TestSuite) TestEnsureReplicaModeForInfoUpdateWOQualifies(c *C) {
 func (s *TestSuite) TestEnsureReplicaModeForInfoUpdateERRDoesNotQualify(c *C) {
 	fmt.Println("Testing ensureReplicaModeForInfoUpdate: ERR mode does not qualify")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	rs := newTestReplicaBackend("replica-1", "10.0.0.1:1234", lhtypes.ModeERR)
 
 	ok := e.ensureReplicaModeForInfoUpdate("replica-1", rs)
@@ -63,7 +65,7 @@ func (s *TestSuite) TestEnsureReplicaModeForInfoUpdateERRDoesNotQualify(c *C) {
 func (s *TestSuite) TestEnsureReplicaModeForInfoUpdateUnexpectedModeDowngradesToERR(c *C) {
 	fmt.Println("Testing ensureReplicaModeForInfoUpdate: unexpected mode is downgraded to ERR")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	rs := newTestReplicaBackend("replica-1", "10.0.0.1:1234", lhtypes.Mode("UNKNOWN"))
 
 	ok := e.ensureReplicaModeForInfoUpdate("replica-1", rs)
@@ -78,7 +80,7 @@ func (s *TestSuite) TestEnsureReplicaModeForInfoUpdateUnexpectedModeDowngradesTo
 func (s *TestSuite) TestCheckAndUpdateInfoFromReplicasNoLockEmptyMap(c *C) {
 	fmt.Println("Testing checkAndUpdateInfoFromReplicasNoLock: empty backends does not panic")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.backends = map[string]Backend{}
 
 	// Should not panic with empty map
@@ -88,7 +90,7 @@ func (s *TestSuite) TestCheckAndUpdateInfoFromReplicasNoLockEmptyMap(c *C) {
 func (s *TestSuite) TestCheckAndUpdateInfoFromReplicasNoLockAllERRSkipped(c *C) {
 	fmt.Println("Testing checkAndUpdateInfoFromReplicasNoLock: all-ERR replicas are skipped without network calls")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.backends = map[string]Backend{
 		"replica-1": newTestReplicaBackend("replica-1", "10.0.0.1:1234", lhtypes.ModeERR),
 		"replica-2": newTestReplicaBackend("replica-2", "10.0.0.2:1234", lhtypes.ModeERR),
@@ -129,7 +131,7 @@ func (s *TestSuite) TestEngineFrontendTeardownRestoreInitiatorMarksStopped(c *C)
 func (s *TestSuite) TestEngineReplicaAddRejectedDuringRestore(c *C) {
 	fmt.Println("Testing Engine.ReplicaAdd is rejected while restore is in progress")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendEmpty, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendEmpty, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.State = lhtypes.InstanceStateRunning
 	e.IsRestoring = true
 
@@ -142,7 +144,7 @@ func (s *TestSuite) TestEngineReplicaAddRejectedDuringRestore(c *C) {
 func (s *TestSuite) TestRecordBackupRestoreStartErrorExposedInRestoreStatus(c *C) {
 	fmt.Println("Testing restore start errors are exposed through Engine.RestoreStatus")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendEmpty, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendEmpty, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.backends = map[string]Backend{
 		"replica-1": newTestReplicaBackend("replica-1", "10.0.0.1:1234", lhtypes.ModeRW),
 		"replica-2": newTestReplicaBackend("replica-2", "10.0.0.2:1234", lhtypes.ModeRW),
@@ -171,7 +173,7 @@ func (s *TestSuite) TestRecordBackupRestoreStartErrorExposedInRestoreStatus(c *C
 func (s *TestSuite) TestRecordBackupRestoreStartErrorPreservesLastRestored(c *C) {
 	fmt.Println("Testing restore start errors preserve last restored backup")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendEmpty, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendEmpty, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.restore = NewEngineRestore(nil, "s3://backupbucket@us-east-1/backupstore?backup=backup-old&volume=vol-a", "backup-old", e, nil)
 	e.restore.FinishRestore()
 
@@ -187,7 +189,7 @@ func (s *TestSuite) TestRecordBackupRestoreStartErrorPreservesLastRestored(c *C)
 func (s *TestSuite) TestCheckAndUpdateInfoFromReplicasNoLockAppliesBackendView(c *C) {
 	fmt.Println("Testing checkAndUpdateInfoFromReplicasNoLock applies SnapshotMap/Head/ActualSize from Backend.Get()")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	u := newFakeBackend("r1", "10.0.0.1:1234")
 	u.SetMode(lhtypes.ModeRW)
 	headLvol := &api.Lvol{Name: "vol-head", Parent: "snap-1"}
@@ -212,7 +214,7 @@ func (s *TestSuite) TestCheckAndUpdateInfoFromReplicasNoLockAppliesBackendView(c
 func (s *TestSuite) TestCheckAndUpdateInfoFromReplicasNoLockMarksERROnGetError(c *C) {
 	fmt.Println("Testing checkAndUpdateInfoFromReplicasNoLock marks backend ERR when Backend.Get() returns an error")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	u := newFakeBackend("r1", "10.0.0.1:1234")
 	u.SetMode(lhtypes.ModeRW)
 	u.ViewErr = errors.New("backend unavailable")
@@ -226,7 +228,7 @@ func (s *TestSuite) TestCheckAndUpdateInfoFromReplicasNoLockMarksERROnGetError(c
 func (s *TestSuite) TestResolveReplicaAncestorRoutesBackingImageThroughBackend(c *C) {
 	fmt.Println("Testing resolveReplicaAncestor calls BackingImageGet via the Backend interface")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	u := newFakeBackend("r1", "10.0.0.1:1234")
 	u.SetMode(lhtypes.ModeRW)
 	biSnap := &api.Lvol{Name: "bi-snap"}
@@ -252,7 +254,7 @@ func (s *TestSuite) TestResolveReplicaAncestorRoutesBackingImageThroughBackend(c
 func (s *TestSuite) TestResolveReplicaAncestorMarksERROnBackingImageError(c *C) {
 	fmt.Println("Testing resolveReplicaAncestor marks backend ERR when BackingImageGet fails")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	u := newFakeBackend("r1", "10.0.0.1:1234")
 	u.SetMode(lhtypes.ModeRW)
 	u.BackingImageGetErr = errors.New("backing image not found")

--- a/pkg/spdk/engine.go
+++ b/pkg/spdk/engine.go
@@ -124,6 +124,14 @@ type Engine struct {
 	ActualSize uint64
 	Frontend   string
 
+	// TransportType is the NVMe-oF transport this engine uses to connect to its
+	// replicas' exposed head bdevs. It must match the transport each replica
+	// used to expose (Replica.TransportType). Set from EngineCreateRequest.
+	// data_engine_transport; unset (empty) is treated as TCP for backward
+	// compatibility. Only the internal engine<->replica data fabric honors this;
+	// the host-facing NVMe-TCP frontend and all EC/transient paths stay TCP.
+	TransportType spdktypes.NvmeTransportType
+
 	ctrlrLossTimeout     int
 	fastIOFailTimeoutSec int
 	// backends maps each peer's name to its Backend. Each one provides a base
@@ -180,7 +188,7 @@ type Engine struct {
 	newServiceClient ServiceClientFactory
 }
 
-func NewEngine(engineName, volumeName, frontend string, specSize uint64, engineUpdateCh chan interface{}, snapshotMaxCount int32, newServiceClient ServiceClientFactory) *Engine {
+func NewEngine(engineName, volumeName, frontend string, transportType spdktypes.NvmeTransportType, specSize uint64, engineUpdateCh chan interface{}, snapshotMaxCount int32, newServiceClient ServiceClientFactory) *Engine {
 	log := logrus.StandardLogger().WithFields(logrus.Fields{
 		"engineName": engineName,
 		"volumeName": volumeName,
@@ -206,6 +214,10 @@ func NewEngine(engineName, volumeName, frontend string, specSize uint64, engineU
 		VolumeName: volumeName,
 		Frontend:   frontend,
 		SpecSize:   specSize,
+
+		// Empty (unset) transportType is treated as TCP by nvmeTransportFromProto,
+		// preserving historical behavior for callers that do not select a transport.
+		TransportType: transportType,
 
 		// TODO: support user-defined values
 		ctrlrLossTimeout:     replicaCtrlrLossTimeoutSec,
@@ -364,8 +376,10 @@ func (e *Engine) createNVMeTCPTarget(spdkClient *spdkclient.Client, superiorPort
 
 	e.log.Infof("Starting to expose RAID bdev for engine target %v on %v:%v with initial ANA state %v, cntlid %v, nsUUID %v",
 		e.Name, e.NvmeTcpTarget.IP, e.NvmeTcpTarget.Port, initialANAState, cntlid, nsUUID)
+	// TODO: the host-facing frontend is always exposed over NVMe-TCP for now.
+	// Adapt it to e.TransportType once the initiator/host side supports RDMA.
 	if err := spdkClient.StartExposeBdevWithANAState(e.NvmeTcpTarget.Nqn, e.Name, e.NvmeTcpTarget.Nguid, nsUUID,
-		e.NvmeTcpTarget.IP, strconv.Itoa(int(e.NvmeTcpTarget.Port)), spdkANAState, cntlid, cntlid); err != nil {
+		e.NvmeTcpTarget.IP, strconv.Itoa(int(e.NvmeTcpTarget.Port)), spdktypes.NvmeTransportTypeTCP, spdkANAState, cntlid, cntlid); err != nil {
 		// No need to release ports here. The engine will be marked as ERR by
 		// Create's deferred error handler, and Delete will release the ports
 		// when the user cleans up this engine.
@@ -387,7 +401,7 @@ func (e *Engine) connectReplicas(spdkClient *spdkclient.Client, replicaAddressMa
 	for replicaName, replicaAddr := range replicaAddressMap {
 		e.backends[replicaName] = backendFactory(replicaName, replicaAddr)
 
-		bdevName, err := connectNVMfBdev(spdkClient, replicaName, replicaAddr, e.ctrlrLossTimeout, e.fastIOFailTimeoutSec, maxRetries, retryInterval)
+		bdevName, err := connectNVMfBdev(spdkClient, replicaName, replicaAddr, e.TransportType, e.ctrlrLossTimeout, e.fastIOFailTimeoutSec, maxRetries, retryInterval)
 		if err != nil {
 			e.log.WithError(err).Warnf("Failed to get bdev from replica %s with address %s during engine creation, will mark the mode to ERR and continue", replicaName, replicaAddr)
 			e.backends[replicaName].SetMode(types.ModeERR)
@@ -1041,7 +1055,7 @@ func (e *Engine) replicaAddStart(spdkClient *spdkclient.Client,
 	}
 
 	// Add rebuilding replica head bdev to the base bdev list of the RAID bdev
-	dstHeadLvolBdevName, err := connectNVMfBdev(spdkClient, dstReplicaName, dstHeadLvolAddress, e.ctrlrLossTimeout, e.fastIOFailTimeoutSec, maxRetries, retryInterval)
+	dstHeadLvolBdevName, err := connectNVMfBdev(spdkClient, dstReplicaName, dstHeadLvolAddress, e.TransportType, e.ctrlrLossTimeout, e.fastIOFailTimeoutSec, maxRetries, retryInterval)
 	if err != nil {
 		return nil, startUpdateRequired, nil, err
 	}
@@ -1878,7 +1892,7 @@ func (e *Engine) replicaSnapshotOperation(spdkClient *spdkclient.Client, replica
 		if err := replicaStatus.SnapshotRevert(snapshotName); err != nil {
 			return err
 		}
-		bdevName, err := connectNVMfBdev(spdkClient, replicaName, replicaStatus.Address(), e.ctrlrLossTimeout, e.fastIOFailTimeoutSec, maxRetries, retryInterval)
+		bdevName, err := connectNVMfBdev(spdkClient, replicaName, replicaStatus.Address(), e.TransportType, e.ctrlrLossTimeout, e.fastIOFailTimeoutSec, maxRetries, retryInterval)
 		if err != nil {
 			return err
 		}
@@ -2919,7 +2933,7 @@ func (e *Engine) Expand(spdkClient *spdkclient.Client, size uint64) (err error) 
 		e.log.Infof("Starting to expose RAID bdev for engine target %v on %v:%v with ANA state %v, cntlid %v, nsUUID %v",
 			e.Name, e.NvmeTcpTarget.IP, e.NvmeTcpTarget.Port, currentANAState, cntlid, nsUUID)
 		if err := spdkClient.StartExposeBdevWithANAState(e.NvmeTcpTarget.Nqn, e.Name, e.NvmeTcpTarget.Nguid, nsUUID,
-			e.NvmeTcpTarget.IP, strconv.Itoa(int(e.NvmeTcpTarget.Port)),
+			e.NvmeTcpTarget.IP, strconv.Itoa(int(e.NvmeTcpTarget.Port)), spdktypes.NvmeTransportTypeTCP,
 			spdkANAState, cntlid, cntlid); err != nil {
 			return errors.Wrapf(err, "failed to start exposing RAID bdev for engine target %v", e.Name)
 		}
@@ -3161,7 +3175,7 @@ func (e *Engine) expandSingleReplica(spdkClient *spdkclient.Client, replicaName 
 		return err
 	}
 
-	_, err = connectNVMfBdev(spdkClient, replicaName, replicaStatus.Address(), e.ctrlrLossTimeout, e.fastIOFailTimeoutSec, maxRetries, retryInterval)
+	_, err = connectNVMfBdev(spdkClient, replicaName, replicaStatus.Address(), e.TransportType, e.ctrlrLossTimeout, e.fastIOFailTimeoutSec, maxRetries, retryInterval)
 	return err
 }
 
@@ -3829,7 +3843,10 @@ func validateAndGetSingleNvmeInfo(replicaName string, bdev *spdktypes.BdevInfo) 
 }
 
 func validateNvmeTransport(replicaName, bdevName string, nvmeInfo spdktypes.NvmeNamespaceInfo) error {
-	if !strings.EqualFold(string(nvmeInfo.Trid.Trtype), string(spdktypes.NvmeTransportTypeTCP)) {
+	// The internal engine<->replica fabric may run over TCP or RDMA (RoCEv2).
+	// Both are valid; only reject transports we never use (e.g. FC, PCIe).
+	if !strings.EqualFold(string(nvmeInfo.Trid.Trtype), string(spdktypes.NvmeTransportTypeTCP)) &&
+		!strings.EqualFold(string(nvmeInfo.Trid.Trtype), string(spdktypes.NvmeTransportTypeRDMA)) {
 		return fmt.Errorf(
 			"found invalid transport type %s in a remote NVMe base bdev %s during replica %s mode validation",
 			nvmeInfo.Trid.Trtype, bdevName, replicaName,

--- a/pkg/spdk/engine_create_test.go
+++ b/pkg/spdk/engine_create_test.go
@@ -7,6 +7,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
+
 	lhtypes "github.com/longhorn/longhorn-spdk-engine/pkg/types"
 )
 
@@ -42,7 +44,7 @@ func (s *TestSuite) TestValidateReplicaSize(c *C) {
 	for _, tc := range cases {
 		fmt.Println("Testing validateReplicaSize:", tc.name)
 
-		e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, tc.engineSize, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+		e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, tc.engineSize, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 
 		addrs := map[string]string{}
 		views := map[string]*BackendView{}

--- a/pkg/spdk/expand_test.go
+++ b/pkg/spdk/expand_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/longhorn/types/pkg/generated/spdkrpc"
 
+	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
 	helpertypes "github.com/longhorn/go-spdk-helper/pkg/types"
 
 	clientpkg "github.com/longhorn/longhorn-spdk-engine/pkg/client"
@@ -22,7 +23,7 @@ import (
 func (s *TestSuite) TestEngineFinishExpansionSuccessClearsErrorState(c *C) {
 	fmt.Println("Testing Engine finish expansion success clears error state")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.State = lhtypes.InstanceStateError
 	e.ErrorMsg = "previous failure"
 
@@ -36,7 +37,7 @@ func (s *TestSuite) TestEngineFinishExpansionSuccessClearsErrorState(c *C) {
 func (s *TestSuite) TestEngineFinishExpansionFailureSetsErrorState(c *C) {
 	fmt.Println("Testing Engine finish expansion failure sets error state")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.State = lhtypes.InstanceStateRunning
 	e.ErrorMsg = ""
 	e.SpecSize = 10
@@ -53,7 +54,7 @@ func (s *TestSuite) TestEngineFinishExpansionFailureSetsErrorState(c *C) {
 func (s *TestSuite) TestEngineFinishExpansionFailureRestoresOriginalSize(c *C) {
 	fmt.Println("Testing Engine finish expansion failure restores original size when spec size was updated during expand")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.SpecSize = 20
 
 	e.finishExpansion(10, 20, errors.New("expand failed"))
@@ -111,7 +112,7 @@ func (s *TestSuite) TestEngineFrontendFinishExpansionFailureWithoutExpansion(c *
 func (s *TestSuite) TestEngineFinishExpansionPartialFailureKeepsOriginalSize(c *C) {
 	fmt.Println("Testing Engine finish expansion partial failure keeps original size")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.lastExpansionError = "replica expand failed"
 
 	e.finishExpansion(10, 20, nil)
@@ -125,7 +126,7 @@ func (s *TestSuite) TestEngineFinishExpansionPartialFailureKeepsOriginalSize(c *
 func (s *TestSuite) TestEngineFinishExpansionPartialFailureRestoresOriginalSize(c *C) {
 	fmt.Println("Testing Engine finish expansion partial failure restores original size when spec size was updated during expand")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.SpecSize = 20
 	e.lastExpansionError = "replica expand failed"
 
@@ -176,12 +177,12 @@ func (s *TestSuite) TestEngineFrontendRequireExpansionGuards(c *C) {
 func (s *TestSuite) TestEngineExpandPrecheckGuards(c *C) {
 	fmt.Println("Testing Engine expand precheck guards")
 
-	eInProgress := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	eInProgress := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	eInProgress.isExpanding = true
 	_, err := eInProgress.ExpandPrecheck(nil, 20)
 	c.Assert(errors.Is(err, ErrExpansionInProgress), Equals, true)
 
-	eRestoring := NewEngine("engine-b", "vol-b", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	eRestoring := NewEngine("engine-b", "vol-b", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	eRestoring.IsRestoring = true
 	_, err = eRestoring.ExpandPrecheck(nil, 20)
 	c.Assert(errors.Is(err, ErrRestoringInProgress), Equals, true)
@@ -210,7 +211,7 @@ func (s *TestSuite) TestEngineExpandPrecheck(c *C) {
 	for _, tc := range cases {
 		fmt.Println("Testing ExpandPrecheck:", tc.name)
 
-		e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+		e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 		ups := map[string]Backend{}
 		i := 1
 		for name, spec := range tc.backends {
@@ -241,7 +242,7 @@ func (s *TestSuite) TestEngineExpandPrecheck(c *C) {
 func (s *TestSuite) TestHandleReplicaExpandResult(c *C) {
 	fmt.Println("Testing Engine handle replica expand result")
 
-	eAllFailed := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	eAllFailed := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	replicaClientsAllFailed := map[string]*clientpkg.SPDKClient{
 		"r1": nil,
 		"r2": nil,
@@ -254,7 +255,7 @@ func (s *TestSuite) TestHandleReplicaExpandResult(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(strings.Contains(err.Error(), "all replicas failed to expand"), Equals, true)
 
-	ePartial := NewEngine("engine-b", "vol-b", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	ePartial := NewEngine("engine-b", "vol-b", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	ePartial.backends = map[string]Backend{
 		"r1": newTestReplicaBackend("r1", "", lhtypes.ModeRW),
 		"r2": newTestReplicaBackend("r2", "", lhtypes.ModeRW),
@@ -296,7 +297,7 @@ func (s *TestSuite) TestExpandViaBackendResetGuards(c *C) {
 		fmt.Println("Testing ExpandViaBackendReset:", tc.name)
 
 		// nil spdkClient is safe: every guard path returns before any SPDK call.
-		e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+		e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 		tc.setup(e)
 		sizeBefore := e.SpecSize
 
@@ -399,7 +400,7 @@ func (s *TestSuite) TestEngineExpandPreservesANAState(c *C) {
 
 	// An engine with ANAState=inaccessible (e.g. a switchover target)
 	// should keep that state across Expand, not revert to optimized.
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.NvmeTcpTarget.ANAState = NvmeTCPANAStateInaccessible
 
 	// Verify the ANA state is preserved in the logic path that Expand uses.
@@ -413,7 +414,7 @@ func (s *TestSuite) TestEngineExpandPreservesANAState(c *C) {
 	c.Assert(err, IsNil)
 
 	// Verify that an empty ANAState defaults to optimized.
-	e2 := NewEngine("engine-b", "vol-b", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e2 := NewEngine("engine-b", "vol-b", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	c.Assert(e2.NvmeTcpTarget.ANAState, Equals, NvmeTCPANAState(""))
 	defaultState := e2.NvmeTcpTarget.ANAState
 	if defaultState == "" {

--- a/pkg/spdk/replica.go
+++ b/pkg/spdk/replica.go
@@ -72,6 +72,10 @@ type Replica struct {
 	LvsUUID string
 	Nqn     string
 
+	// TransportType is the NVMe-oF transport this replica exposes its bdev over so the
+	// engine can connect. Defaults to TCP; set to RDMA for RoCEv2/InfiniBand.
+	TransportType spdktypes.NvmeTransportType
+
 	SpecSize   uint64
 	ActualSize uint64
 
@@ -319,11 +323,12 @@ func NewReplica(ctx context.Context, replicaName, lvsName, lvsUUID string, specS
 	return &Replica{
 		ctx: ctx,
 
-		Name:    replicaName,
-		Alias:   spdktypes.GetLvolAlias(lvsName, replicaName),
-		LvsName: lvsName,
-		LvsUUID: lvsUUID,
-		Nqn:     helpertypes.GetNQN(replicaName),
+		Name:          replicaName,
+		Alias:         spdktypes.GetLvolAlias(lvsName, replicaName),
+		LvsName:       lvsName,
+		LvsUUID:       lvsUUID,
+		Nqn:           helpertypes.GetNQN(replicaName),
+		TransportType: spdktypes.NvmeTransportTypeTCP,
 
 		SpecSize: roundedSpecSize,
 		State:    types.InstanceStatePending,
@@ -1002,7 +1007,9 @@ func getExposedPort(subsystem *spdktypes.NvmfSubsystem) (exposedPort int32, err 
 
 	port := 0
 	for _, listenAddr := range subsystem.ListenAddresses {
-		if !strings.EqualFold(string(listenAddr.Trtype), string(spdktypes.NvmeTransportTypeTCP)) {
+		// Accept either NVMe-oF transport a Longhorn replica may be exposed over.
+		if !strings.EqualFold(string(listenAddr.Trtype), string(spdktypes.NvmeTransportTypeTCP)) &&
+			!strings.EqualFold(string(listenAddr.Trtype), string(spdktypes.NvmeTransportTypeRDMA)) {
 			continue
 		}
 		port, err = strconv.Atoi(listenAddr.Trsvcid)
@@ -1513,7 +1520,7 @@ func (r *Replica) Create(spdkClient *spdkclient.Client, portCount int32, superio
 	}
 
 	if err := spdkClient.StartExposeBdev(r.Nqn, r.Head.UUID, generateNGUID(r.Name), r.IP, strconv.Itoa(int(r.PortStart)),
-		helpertypes.InternalHostNQN); err != nil {
+		r.TransportType, helpertypes.InternalHostNQN); err != nil {
 		return nil, err
 	}
 
@@ -1806,7 +1813,7 @@ func (r *Replica) Expand(spdkClient *spdkclient.Client, size uint64) error {
 	// If we had previously exposed the bdev, we must re-expose it after the resize.
 	if reExposeBdev {
 		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.Name), r.Head.UUID, generateNGUID(r.Name), r.IP, strconv.Itoa(int(r.PortStart)),
-			helpertypes.InternalHostNQN); err != nil {
+			r.TransportType, helpertypes.InternalHostNQN); err != nil {
 			return errors.Wrapf(err, "failed to start expose replica %v after expansion", r.Name)
 		}
 		r.IsExposed = true
@@ -2167,7 +2174,7 @@ func (r *Replica) SnapshotRevert(spdkClient *spdkclient.Client, snapshotName str
 		r.IsExposed = false
 
 		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.Name), headLvolUUID, generateNGUID(r.Name), r.IP, strconv.Itoa(int(r.PortStart)),
-			helpertypes.InternalHostNQN); err != nil {
+			r.TransportType, helpertypes.InternalHostNQN); err != nil {
 			return nil, err
 		}
 		r.IsExposed = true
@@ -2530,9 +2537,12 @@ func (r *Replica) SnapshotCloneDstStart(spdkClient *spdkclient.Client, snapshotN
 	}
 	r.snapshotCloningDstCache.cloningLvol = BdevLvolInfoToServiceLvol(&cloningBdevLvol)
 
+	// TODO: transient internal paths (clone here, plus rebuilding and expansion
+	// below) are always exposed/connected over NVMe-TCP for now. Evaluate honoring
+	// r.TransportType (RDMA) on these paths in a follow-up.
 	if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.snapshotCloningDstCache.cloningLvol.Name),
 		r.snapshotCloningDstCache.cloningLvol.UUID, generateNGUID(r.snapshotCloningDstCache.cloningLvol.Name), r.IP,
-		strconv.Itoa(int(r.snapshotCloningDstCache.cloningPort)), helpertypes.InternalHostNQN); err != nil {
+		strconv.Itoa(int(r.snapshotCloningDstCache.cloningPort)), spdktypes.NvmeTransportTypeTCP, helpertypes.InternalHostNQN); err != nil {
 		return err
 	}
 	dstCloningLvolAddress := net.JoinHostPort(r.IP, strconv.Itoa(int(r.snapshotCloningDstCache.cloningPort)))
@@ -3159,7 +3169,7 @@ func (r *Replica) SnapshotCloneSrcStart(spdkClient *spdkclient.Client, snapshotN
 
 	dstCloningLvolName := GetReplicaCloningLvolName(dstReplicaName)
 	dstCloningBdevName, err := connectNVMfBdev(spdkClient, dstCloningLvolName, dstCloningLvolAddress,
-		replicaCtrlrLossTimeoutSec, replicaFastIOFailTimeoutSec, maxRetries, retryInterval)
+		spdktypes.NvmeTransportTypeTCP, replicaCtrlrLossTimeoutSec, replicaFastIOFailTimeoutSec, maxRetries, retryInterval)
 	if err != nil {
 		return err
 	}
@@ -3289,7 +3299,7 @@ func (r *Replica) RebuildingSrcStart(spdkClient *spdkclient.Client, dstReplicaNa
 		return "", err
 	}
 	if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(snapLvol.Name), snapLvol.UUID, generateNGUID(snapLvol.Name), r.IP, strconv.Itoa(int(port)),
-		helpertypes.InternalHostNQN); err != nil {
+		spdktypes.NvmeTransportTypeTCP, helpertypes.InternalHostNQN); err != nil {
 		return "", err
 	}
 	exposedSnapshotLvolAddress = net.JoinHostPort(r.IP, strconv.Itoa(int(port)))
@@ -3372,7 +3382,7 @@ func (r *Replica) rebuildingSrcAttachNoLock(spdkClient *spdkclient.Client, dstRe
 		return nil
 	}
 
-	r.rebuildingSrcCache.dstRebuildingBdevName, err = connectNVMfBdev(spdkClient, dstRebuildingLvolName, dstRebuildingLvolAddress, replicaCtrlrLossTimeoutSec, replicaFastIOFailTimeoutSec, maxRetries, retryInterval)
+	r.rebuildingSrcCache.dstRebuildingBdevName, err = connectNVMfBdev(spdkClient, dstRebuildingLvolName, dstRebuildingLvolAddress, spdktypes.NvmeTransportTypeTCP, replicaCtrlrLossTimeoutSec, replicaFastIOFailTimeoutSec, maxRetries, retryInterval)
 	if err != nil {
 		return errors.Wrapf(err, "failed to connect rebuilding lvol %s with address %s as a NVMe bdev for replica %s rebuilding src attach", dstRebuildingLvolName, dstRebuildingLvolAddress, r.Name)
 	}
@@ -3805,7 +3815,7 @@ func (r *Replica) RebuildingDstStart(spdkClient *spdkclient.Client, srcReplicaNa
 
 	externalSnapshotLvolName := GetReplicaSnapshotLvolName(srcReplicaName, externalSnapshotName)
 	externalSnapshotBdevName, err := connectNVMfBdev(spdkClient, externalSnapshotLvolName, externalSnapshotAddress,
-		replicaCtrlrLossTimeoutSec, replicaFastIOFailTimeoutSec, maxRetries, retryInterval)
+		spdktypes.NvmeTransportTypeTCP, replicaCtrlrLossTimeoutSec, replicaFastIOFailTimeoutSec, maxRetries, retryInterval)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to connect the external src snapshot lvol %s with address %s as a NVMf bdev for dst replica %v rebuilding start", externalSnapshotLvolName, externalSnapshotAddress, r.Name)
 	}
@@ -3869,7 +3879,7 @@ func (r *Replica) RebuildingDstStart(spdkClient *spdkclient.Client, srcReplicaNa
 	r.ActiveChain = append(r.ActiveChain, r.Head)
 
 	if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.Name), r.Head.UUID, generateNGUID(r.Name), r.IP, strconv.Itoa(int(r.PortStart)),
-		helpertypes.InternalHostNQN); err != nil {
+		r.TransportType, helpertypes.InternalHostNQN); err != nil {
 		return "", err
 	}
 	r.IsExposed = true
@@ -4402,7 +4412,7 @@ func (r *Replica) rebuildingDstShallowCopyPrepare(spdkClient *spdkclient.Client,
 	if r.rebuildingDstCache.rebuildingPort != 0 {
 		if err := spdkClient.StartExposeBdev(helpertypes.GetNQN(r.rebuildingDstCache.rebuildingLvol.Name), r.rebuildingDstCache.rebuildingLvol.UUID,
 			generateNGUID(r.rebuildingDstCache.rebuildingLvol.Name), r.IP, strconv.Itoa(int(r.rebuildingDstCache.rebuildingPort)),
-			helpertypes.InternalHostNQN); err != nil {
+			spdktypes.NvmeTransportTypeTCP, helpertypes.InternalHostNQN); err != nil {
 			return "", false, err
 		}
 		dstRebuildingLvolAddress = net.JoinHostPort(r.IP, strconv.Itoa(int(r.rebuildingDstCache.rebuildingPort)))

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -743,7 +743,7 @@ func (s *Server) newReplica(req *spdkrpc.ReplicaCreateRequest) (*Replica, error)
 		}
 		// Refresh the NVMe-oF transport used to expose this replica's head.
 		// Unset (TCP=0) preserves historical TCP behavior.
-		r.TransportType = nvmeTransportFromProto(req.DataEngineTransport)
+		r.TransportType = nvmeTransportFromProto(req.TransportType)
 		r.Unlock()
 		return r, nil
 	}
@@ -758,7 +758,7 @@ func (s *Server) newReplica(req *spdkrpc.ReplicaCreateRequest) (*Replica, error)
 	r = NewReplica(s.ctx, req.Name, req.LvsName, req.LvsUuid, req.SpecSize, true, s.updateChs[types.InstanceTypeReplica], s.newServiceClient)
 	// Select the NVMe-oF transport used to expose this replica's head. Unset
 	// (TCP=0) preserves historical TCP behavior; must match the engine's transport.
-	r.TransportType = nvmeTransportFromProto(req.DataEngineTransport)
+	r.TransportType = nvmeTransportFromProto(req.TransportType)
 	return r, nil
 }
 

--- a/pkg/spdk/server.go
+++ b/pkg/spdk/server.go
@@ -741,6 +741,9 @@ func (s *Server) newReplica(req *spdkrpc.ReplicaCreateRequest) (*Replica, error)
 		if req.LvsUuid != "" {
 			r.LvsUUID = req.LvsUuid
 		}
+		// Refresh the NVMe-oF transport used to expose this replica's head.
+		// Unset (TCP=0) preserves historical TCP behavior.
+		r.TransportType = nvmeTransportFromProto(req.DataEngineTransport)
 		r.Unlock()
 		return r, nil
 	}
@@ -752,7 +755,11 @@ func (s *Server) newReplica(req *spdkrpc.ReplicaCreateRequest) (*Replica, error)
 	if !exists {
 		return nil, fmt.Errorf("lvstore %v(%v) does not exist for replica %v creation", req.LvsName, req.LvsUuid, req.Name)
 	}
-	return NewReplica(s.ctx, req.Name, req.LvsName, req.LvsUuid, req.SpecSize, true, s.updateChs[types.InstanceTypeReplica], s.newServiceClient), nil
+	r = NewReplica(s.ctx, req.Name, req.LvsName, req.LvsUuid, req.SpecSize, true, s.updateChs[types.InstanceTypeReplica], s.newServiceClient)
+	// Select the NVMe-oF transport used to expose this replica's head. Unset
+	// (TCP=0) preserves historical TCP behavior; must match the engine's transport.
+	r.TransportType = nvmeTransportFromProto(req.DataEngineTransport)
+	return r, nil
 }
 
 func (s *Server) getBackingImage(backingImageName, lvsUUID string) (backingImage *BackingImage, err error) {

--- a/pkg/spdk/server_engine.go
+++ b/pkg/spdk/server_engine.go
@@ -42,7 +42,7 @@ func (s *Server) EngineCreate(ctx context.Context, req *spdkrpc.EngineCreateRequ
 		// Select the internal engine<->replica NVMe-oF transport. Unset (TCP=0)
 		// preserves historical TCP behavior. Must match the transport the replicas
 		// used to expose their heads.
-		transportType := nvmeTransportFromProto(req.DataEngineTransport)
+		transportType := nvmeTransportFromProto(req.TransportType)
 		s.engineMap[req.Name] = NewEngine(req.Name, req.VolumeName, req.Frontend, transportType, req.SpecSize, s.updateChs[types.InstanceTypeEngine], req.SnapshotMaxCount, s.newServiceClient)
 		e = s.engineMap[req.Name]
 	}

--- a/pkg/spdk/server_engine.go
+++ b/pkg/spdk/server_engine.go
@@ -39,7 +39,11 @@ func (s *Server) EngineCreate(ctx context.Context, req *spdkrpc.EngineCreateRequ
 	}
 
 	if e == nil {
-		s.engineMap[req.Name] = NewEngine(req.Name, req.VolumeName, req.Frontend, req.SpecSize, s.updateChs[types.InstanceTypeEngine], req.SnapshotMaxCount, s.newServiceClient)
+		// Select the internal engine<->replica NVMe-oF transport. Unset (TCP=0)
+		// preserves historical TCP behavior. Must match the transport the replicas
+		// used to expose their heads.
+		transportType := nvmeTransportFromProto(req.DataEngineTransport)
+		s.engineMap[req.Name] = NewEngine(req.Name, req.VolumeName, req.Frontend, transportType, req.SpecSize, s.updateChs[types.InstanceTypeEngine], req.SnapshotMaxCount, s.newServiceClient)
 		e = s.engineMap[req.Name]
 	}
 

--- a/pkg/spdk/server_engine_test.go
+++ b/pkg/spdk/server_engine_test.go
@@ -7,6 +7,7 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 
+	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
 	"github.com/longhorn/types/pkg/generated/spdkrpc"
 
 	lhtypes "github.com/longhorn/longhorn-spdk-engine/pkg/types"
@@ -17,7 +18,7 @@ import (
 func (s *TestSuite) TestServerEngineReplicaListEmptyForShardedEngine(c *C) {
 	fmt.Println("Testing Server.EngineReplicaList returns an empty replica map for EC engines")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.backends = map[string]Backend{
 		"sg1": newShardGroupBackend("sg1", "10.0.0.1:1234", nil),
 	}
@@ -51,7 +52,7 @@ func (s *TestSuite) TestServerEngineReplicaListNotFound(c *C) {
 func (s *TestSuite) TestServerEngineReplicaAddRejectedOnShardedEngine(c *C) {
 	fmt.Println("Testing Server.EngineReplicaAdd rejects EC engines with FailedPrecondition")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.backends = map[string]Backend{
 		"sg1": newShardGroupBackend("sg1", "10.0.0.1:1234", nil),
 	}
@@ -72,7 +73,7 @@ func (s *TestSuite) TestServerEngineReplicaAddRejectedOnShardedEngine(c *C) {
 func (s *TestSuite) TestServerEngineReplicaDeleteRejectedOnShardedEngine(c *C) {
 	fmt.Println("Testing Server.EngineReplicaDelete rejects EC engines with FailedPrecondition")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.backends = map[string]Backend{
 		"sg1": newShardGroupBackend("sg1", "10.0.0.1:1234", nil),
 	}
@@ -93,7 +94,7 @@ func (s *TestSuite) TestServerEngineReplicaDeleteRejectedOnShardedEngine(c *C) {
 func (s *TestSuite) TestServerEngineSnapshotHashStatusUnimplementedForShardedEngine(c *C) {
 	fmt.Println("Testing Server.EngineSnapshotHashStatus returns Unimplemented for EC engines")
 
-	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.backends = map[string]Backend{
 		"sg1": newShardGroupBackend("sg1", "10.0.0.1:1234", nil),
 	}

--- a/pkg/spdk/server_verify_test.go
+++ b/pkg/spdk/server_verify_test.go
@@ -133,7 +133,7 @@ func (s *TestSuite) TestHandleVerifyErrorBrokenPipe(c *C) {
 	fmt.Println("Testing handleVerifyError with broken pipe error")
 
 	replica := NewReplica(context.Background(), "r1", "disk-a", "uuid-a", 1024, true, make(chan interface{}, 1), nil)
-	engine := NewEngine("e1", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 1024, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	engine := NewEngine("e1", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 1024, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	engineFrontend := NewEngineFrontend("ef1", "e1", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 1024, 0, 0, make(chan interface{}, 1), nil)
 
 	replica.State = lhtypes.InstanceStateRunning
@@ -211,7 +211,7 @@ func (s *TestSuite) TestHandleVerifyErrorBrokenPipeKeepsStoppedAndError(c *C) {
 	replicaStopped := NewReplica(context.Background(), "r-stopped", "disk-a", "uuid-a", 1024, true, make(chan interface{}, 1), nil)
 	replicaStopped.State = lhtypes.InstanceStateStopped
 
-	engineErrored := NewEngine("e-err", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 1024, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	engineErrored := NewEngine("e-err", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 1024, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	engineErrored.State = lhtypes.InstanceStateError
 
 	engineFrontendRunning := NewEngineFrontend("ef-run", "e-err", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 1024, 0, 0, make(chan interface{}, 1), nil)
@@ -333,7 +333,7 @@ func (s *TestSuite) TestNewVerifyStateLockedCopiesMaps(c *C) {
 			"r1": NewReplica(context.Background(), "r1", "disk-a", "uuid-a", 1024, true, make(chan interface{}, 1), nil),
 		},
 		engineMap: map[string]*Engine{
-			"e1": NewEngine("e1", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 1024, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil),
+			"e1": NewEngine("e1", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 1024, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil),
 		},
 		engineFrontendMap: map[string]*EngineFrontend{
 			"ef1": NewEngineFrontend("ef1", "e1", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 1024, 0, 0, make(chan interface{}, 1), nil),

--- a/pkg/spdk/shard.go
+++ b/pkg/spdk/shard.go
@@ -190,7 +190,7 @@ func (s *Shard) Create(spdkClient *spdkclient.Client, superiorPortAllocator *com
 		return nil, err
 	}
 
-	if err := spdkClient.StartExposeBdev(s.Nqn, s.UUID, generateNGUID(s.LvolName), s.IP, strconv.Itoa(int(s.Port)),
+	if err := spdkClient.StartExposeBdev(s.Nqn, s.UUID, generateNGUID(s.LvolName), s.IP, strconv.Itoa(int(s.Port)), spdktypes.NvmeTransportTypeTCP,
 		helpertypes.InternalHostNQN); err != nil {
 		return nil, errors.Wrapf(err, "failed to expose bdev for shard %s", s.Name)
 	}
@@ -419,7 +419,7 @@ func (s *Shard) Expand(spdkClient *spdkclient.Client, newSize uint64) (err error
 	}
 
 	if reExposeBdev {
-		if err := spdkClient.StartExposeBdev(s.Nqn, s.UUID, generateNGUID(s.LvolName), s.IP, strconv.Itoa(int(s.Port)),
+		if err := spdkClient.StartExposeBdev(s.Nqn, s.UUID, generateNGUID(s.LvolName), s.IP, strconv.Itoa(int(s.Port)), spdktypes.NvmeTransportTypeTCP,
 			helpertypes.InternalHostNQN); err != nil {
 			return errors.Wrapf(err, "failed to re-expose shard %s after expansion", s.Name)
 		}

--- a/pkg/spdk/shardgroup.go
+++ b/pkg/spdk/shardgroup.go
@@ -598,7 +598,7 @@ func (sg *ShardGroup) Create(spdkClient *spdkclient.Client, superiorPortAllocato
 			connectAttempts = salvageConnectMaxRetries
 		}
 		bdevName, connErr := connectNVMfBdev(spdkClient, controllerName, endpoint.Address,
-			ecShardCtrlrLossTimeoutSec, ecShardFastIOFailTimeoutSec, connectAttempts, retryInterval)
+			spdktypes.NvmeTransportTypeTCP, ecShardCtrlrLossTimeoutSec, ecShardFastIOFailTimeoutSec, connectAttempts, retryInterval)
 		if connErr != nil {
 			if sg.SalvageRequested {
 				sg.log.WithError(connErr).Warnf("Salvage: failed to connect shard %s at %s; marking slot %d as missing", controllerName, endpoint.Address, endpoint.SlotIndex)
@@ -715,7 +715,7 @@ func (sg *ShardGroup) Create(spdkClient *spdkclient.Client, superiorPortAllocato
 		return nil, err
 	}
 	if err := spdkClient.StartExposeBdev(sg.Nqn, sg.HeadLvolUUID, generateNGUID(sg.HeadLvolName),
-		sg.IP, strconv.Itoa(int(sg.Port)), helpertypes.InternalHostNQN); err != nil {
+		sg.IP, strconv.Itoa(int(sg.Port)), spdktypes.NvmeTransportTypeTCP, helpertypes.InternalHostNQN); err != nil {
 		return nil, errors.Wrapf(err, "failed to expose head lvol for shardgroup %s", sg.Name)
 	}
 	sg.IsExposed = true
@@ -1079,7 +1079,7 @@ func (sg *ShardGroup) Expand(spdkClient *spdkclient.Client, newSize, creationSiz
 	}
 
 	if err := spdkClient.StartExposeBdev(sg.Nqn, sg.HeadLvolUUID, generateNGUID(sg.HeadLvolName),
-		sg.IP, strconv.Itoa(int(sg.Port)), helpertypes.InternalHostNQN); err != nil {
+		sg.IP, strconv.Itoa(int(sg.Port)), spdktypes.NvmeTransportTypeTCP, helpertypes.InternalHostNQN); err != nil {
 		return errors.Wrapf(err, "failed to re-expose shardgroup %s after head-lvol resize", sg.Name)
 	}
 
@@ -1263,7 +1263,7 @@ func (sg *ShardGroup) SnapshotRevert(spdkClient *spdkclient.Client, snapshotName
 	sg.HeadLvolUUID = newHeadUUID
 
 	if err := spdkClient.StartExposeBdev(sg.Nqn, sg.HeadLvolUUID, generateNGUID(sg.HeadLvolName),
-		sg.IP, strconv.Itoa(int(sg.Port)), helpertypes.InternalHostNQN); err != nil {
+		sg.IP, strconv.Itoa(int(sg.Port)), spdktypes.NvmeTransportTypeTCP, helpertypes.InternalHostNQN); err != nil {
 		return errors.Wrapf(err, "failed to re-expose head lvol after revert")
 	}
 	sg.IsExposed = true
@@ -1354,7 +1354,7 @@ func (sg *ShardGroup) ShardReplace(spdkClient *spdkclient.Client, shardName, sha
 	}
 
 	bdevName, err := connectNVMfBdev(spdkClient, controllerName, shardAddress,
-		ecShardCtrlrLossTimeoutSec, ecShardFastIOFailTimeoutSec, maxRetries, retryInterval)
+		spdktypes.NvmeTransportTypeTCP, ecShardCtrlrLossTimeoutSec, ecShardFastIOFailTimeoutSec, maxRetries, retryInterval)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to connect replacement shard %s at %s", controllerName, shardAddress)
 	}

--- a/pkg/spdk/snapshot_test.go
+++ b/pkg/spdk/snapshot_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
+
 	"github.com/longhorn/longhorn-spdk-engine/pkg/api"
 	"github.com/longhorn/longhorn-spdk-engine/pkg/types"
 
@@ -14,7 +16,7 @@ import (
 func (s *TestSuite) TestSnapshotOperationPreCheckCreateGeneratesName(c *C) {
 	fmt.Println("Testing snapshotOperationPreCheckWithoutLock generates snapshot name for create operation")
 
-	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 
 	snapshotName, err := e.snapshotOperationPreCheckWithoutLock("", SnapshotOperationCreate)
 	c.Assert(err, IsNil)
@@ -25,7 +27,7 @@ func (s *TestSuite) TestSnapshotOperationPreCheckCreateGeneratesName(c *C) {
 func (s *TestSuite) TestSnapshotOperationPreCheckDeleteEmptyName(c *C) {
 	fmt.Println("Testing snapshotOperationPreCheckWithoutLock returns error for delete operation with empty snapshot name")
 
-	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 
 	_, err := e.snapshotOperationPreCheckWithoutLock("", SnapshotOperationDelete)
 	c.Assert(err, NotNil)
@@ -35,7 +37,7 @@ func (s *TestSuite) TestSnapshotOperationPreCheckDeleteEmptyName(c *C) {
 func (s *TestSuite) TestSnapshotOperationPreCheckCreateFailsWhenSnapshotMaxCountReached(c *C) {
 	fmt.Println("Testing snapshotOperationPreCheckWithoutLock returns error when snapshot max count is reached")
 
-	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.SnapshotMaxCount = 2
 	e.SnapshotMap["snap-1"] = &api.Lvol{Name: "snap-1"}
 	e.SnapshotMap["snap-2"] = &api.Lvol{Name: "snap-2"}
@@ -48,7 +50,7 @@ func (s *TestSuite) TestSnapshotOperationPreCheckCreateFailsWhenSnapshotMaxCount
 func (s *TestSuite) TestSnapshotOperationPreCheckRevertReadsSnapshotsViaBackend(c *C) {
 	fmt.Println("Testing snapshotOperationPreCheckWithoutLock for revert reads snapshot map via Backend.Get()")
 
-	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.Frontend = types.FrontendEmpty // revert requires empty frontend
 	u := newFakeBackend("r1", "10.0.0.1:1234")
 	u.SetMode(types.ModeRW)
@@ -67,7 +69,7 @@ func (s *TestSuite) TestSnapshotOperationPreCheckRevertReadsSnapshotsViaBackend(
 func (s *TestSuite) TestSnapshotOperationPreCheckRevertRejectsMissingSnapshot(c *C) {
 	fmt.Println("Testing snapshotOperationPreCheckWithoutLock for revert rejects when snapshot is absent from Backend.Get()")
 
-	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.Frontend = types.FrontendEmpty
 	u := newFakeBackend("r1", "10.0.0.1:1234")
 	u.SetMode(types.ModeRW)
@@ -85,7 +87,7 @@ func (s *TestSuite) TestSnapshotOperationPreCheckRevertRejectsMissingSnapshot(c 
 func (s *TestSuite) TestSnapshotOperationPreCheckRevertPropagatesBackendError(c *C) {
 	fmt.Println("Testing snapshotOperationPreCheckWithoutLock for revert propagates Backend.Get() error")
 
-	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.Frontend = types.FrontendEmpty
 	u := newFakeBackend("r1", "10.0.0.1:1234")
 	u.SetMode(types.ModeRW)
@@ -100,7 +102,7 @@ func (s *TestSuite) TestSnapshotOperationPreCheckRevertPropagatesBackendError(c 
 func (s *TestSuite) TestSnapshotOperationPreCheckSkipsNonDispatchableBackends(c *C) {
 	fmt.Println("Testing snapshotOperationPreCheckWithoutLock skips non-dispatchable backends")
 
-	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	e.Frontend = types.FrontendEmpty
 
 	dispatchable := newFakeBackend("r1", "10.0.0.1:1234")
@@ -127,7 +129,7 @@ func (s *TestSuite) TestSnapshotOperationPreCheckSkipsNonDispatchableBackends(c 
 }
 
 func newEngineWithFakeBackend() (*Engine, *fakeBackend) {
-	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("engine-a", "vol-a", types.FrontendSPDKTCPBlockdev, spdktypes.NvmeTransportTypeTCP, 10, make(chan interface{}, 1), defaultTestSnapshotMaxCount, nil)
 	u := newFakeBackend("r1", "10.0.0.1:1234")
 	u.SetMode(types.ModeRW)
 	e.backends = map[string]Backend{"r1": u}

--- a/pkg/spdk/util.go
+++ b/pkg/spdk/util.go
@@ -21,6 +21,8 @@ import (
 	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
 	helpertypes "github.com/longhorn/go-spdk-helper/pkg/types"
 	helperutil "github.com/longhorn/go-spdk-helper/pkg/util"
+
+	"github.com/longhorn/types/pkg/generated/spdkrpc"
 )
 
 func discoverAndConnectNVMeTarget(srcIP string, srcPort int32, maxRetries int, retryInterval time.Duration) (subsystemNQN, controllerName string, err error) {
@@ -74,7 +76,9 @@ func exposeSnapshotLvolBdev(spdkClient *spdkclient.Client, lvsName, lvolName, ip
 	}
 
 	portStr := strconv.Itoa(int(port))
-	err = spdkClient.StartExposeBdev(helpertypes.GetNQN(lvolName), bdevLvolList[0].UUID, generateNGUID(lvolName), ip, portStr)
+	// Backup/restore snapshot export stays on TCP for the MVP; only the
+	// engine<->replica head fabric is transport-selectable.
+	err = spdkClient.StartExposeBdev(helpertypes.GetNQN(lvolName), bdevLvolList[0].UUID, generateNGUID(lvolName), ip, portStr, spdktypes.NvmeTransportTypeTCP)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "failed to expose snapshot lvol bdev %v", lvolName)
 	}
@@ -119,11 +123,32 @@ func splitHostPort(address string) (string, int32, error) {
 	return address, 0, nil
 }
 
-// connectNVMfBdev connects to the NVMe/TCP target, which is exposed by a remote lvol bdev.
-// controllerName is typically the lvol name, and address is the IP:port of the NVMe/TCP target.
-func connectNVMfBdev(spdkClient *spdkclient.Client, controllerName, address string, ctrlrLossTimeout, fastIOFailTimeoutSec int, maxRetries int, retryInterval time.Duration) (bdevName string, err error) {
+// nvmeTransportFromProto maps the spdkrpc.DataEngineTransport enum to the
+// go-spdk-helper NVMe transport type used throughout the engine/replica code.
+// The zero value (DATA_ENGINE_TRANSPORT_TCP) maps to TCP so that engines and
+// replicas created by an older control plane - which never sets the field -
+// keep their historical TCP behavior.
+func nvmeTransportFromProto(t spdkrpc.DataEngineTransport) spdktypes.NvmeTransportType {
+	switch t {
+	case spdkrpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_RDMA:
+		return spdktypes.NvmeTransportTypeRDMA
+	default:
+		return spdktypes.NvmeTransportTypeTCP
+	}
+}
+
+// connectNVMfBdev connects to the NVMe-oF target, which is exposed by a remote lvol bdev.
+// controllerName is typically the lvol name, and address is the IP:port of the NVMe-oF target.
+// trtype selects the NVMe-oF transport (TCP or RDMA); it must match the transport the
+// remote side used to expose the bdev. An empty trtype defaults to TCP for backward
+// compatibility.
+func connectNVMfBdev(spdkClient *spdkclient.Client, controllerName, address string, trtype spdktypes.NvmeTransportType, ctrlrLossTimeout, fastIOFailTimeoutSec int, maxRetries int, retryInterval time.Duration) (bdevName string, err error) {
 	if controllerName == "" || address == "" {
 		return "", fmt.Errorf("controllerName or address is empty")
+	}
+
+	if trtype == "" {
+		trtype = spdktypes.NvmeTransportTypeTCP
 	}
 
 	defer func() {
@@ -165,7 +190,7 @@ func connectNVMfBdev(spdkClient *spdkclient.Client, controllerName, address stri
 				helpertypes.GetNQN(controllerName),
 				ip,
 				port,
-				spdktypes.NvmeTransportTypeTCP,
+				trtype,
 				adrfam,
 				int32(ctrlrLossTimeout),
 				replicaReconnectDelaySec,

--- a/pkg/spdk/util.go
+++ b/pkg/spdk/util.go
@@ -123,14 +123,14 @@ func splitHostPort(address string) (string, int32, error) {
 	return address, 0, nil
 }
 
-// nvmeTransportFromProto maps the spdkrpc.DataEngineTransport enum to the
+// nvmeTransportFromProto maps the spdkrpc.TransportType enum to the
 // go-spdk-helper NVMe transport type used throughout the engine/replica code.
-// The zero value (DATA_ENGINE_TRANSPORT_TCP) maps to TCP so that engines and
+// The zero value (TRANSPORT_TYPE_TCP) maps to TCP so that engines and
 // replicas created by an older control plane - which never sets the field -
 // keep their historical TCP behavior.
-func nvmeTransportFromProto(t spdkrpc.DataEngineTransport) spdktypes.NvmeTransportType {
+func nvmeTransportFromProto(t spdkrpc.TransportType) spdktypes.NvmeTransportType {
 	switch t {
-	case spdkrpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_RDMA:
+	case spdkrpc.TransportType_TRANSPORT_TYPE_RDMA:
 		return spdktypes.NvmeTransportTypeRDMA
 	default:
 		return spdktypes.NvmeTransportTypeTCP

--- a/pkg/spdk/util_test.go
+++ b/pkg/spdk/util_test.go
@@ -135,7 +135,7 @@ func (s *TestSuite) TestExtractBackingImageAndDiskUUID(c *C) {
 }
 
 func (s *TestSuite) TestSetReplicaAdderInjectsRealFallback(c *C) {
-	e := NewEngine("test-engine", "test-volume", types.FrontendEmpty, 1, nil, defaultTestSnapshotMaxCount, nil)
+	e := NewEngine("test-engine", "test-volume", types.FrontendEmpty, spdktypes.NvmeTransportTypeTCP, 1, nil, defaultTestSnapshotMaxCount, nil)
 
 	firstMock := &MockReplicaAdder{}
 	e.SetReplicaAdder(firstMock)


### PR DESCRIPTION
Part of longhorn/longhorn#13796. **Depends on longhorn/types#121 and longhorn/go-spdk-helper#308.**

Carry the `DataEngineTransport` from the spdkrpc create requests into replica and engine setup: create the matching NVMe-oF transport (RDMA or TCP) on the SPDK target, add the listener with the right trtype, and connect the engine's controllers over the selected transport. RDMA uses RoCEv2 (`adrfam=ipv4`). Unset means TCP; existing volumes and the host frontend are unaffected (frontend stays TCP).

Files: `pkg/spdk/{engine,replica,server,server_engine,util,shard,shardgroup}.go`, `pkg/client/{client_engine,client_replica}.go`.
