### PR TITLE
fix(porting): bump go-spdk-helper to decode dma_device_type as string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jinzhu/copier v0.4.0
 	github.com/longhorn/backupstore v0.0.0-20260820153238-ab5179ec9ca0
 	github.com/longhorn/go-common-libs v0.0.0-20260730002911-add09e6eb92c
-	github.com/longhorn/go-spdk-helper v0.9.1-0.20260814082531-318b4a23bb34
+	github.com/longhorn/go-spdk-helper v0.9.1-0.20260828012436-4ec507083142
 	github.com/longhorn/types v0.0.0-20260814104707-529643438923
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/longhorn/backupstore v0.0.0-20260820153238-ab5179ec9ca0 h1:uCHIrr18ha
 github.com/longhorn/backupstore v0.0.0-20260820153238-ab5179ec9ca0/go.mod h1:Vb1kh30oG5znu8vpr/imYLzf6gq23mietPXrHtxSwVw=
 github.com/longhorn/go-common-libs v0.0.0-20260730002911-add09e6eb92c h1:WR2BAcTwBRv2fKxd+z066GWQj2Ioq+m5pPpjK2fvxwk=
 github.com/longhorn/go-common-libs v0.0.0-20260730002911-add09e6eb92c/go.mod h1:pjOR2fdQA0dNp3is1xfA+Ni2PjPDP+JuOoSEjdL2cfQ=
-github.com/longhorn/go-spdk-helper v0.9.1-0.20260814082531-318b4a23bb34 h1:Z2wW5IKkz3NaLsVYl2TsBjAt2jhbMsHeIUsqTFvY5XY=
-github.com/longhorn/go-spdk-helper v0.9.1-0.20260814082531-318b4a23bb34/go.mod h1:YUwrW7NQVp3WS4o/i2ModjHu7BELeJWBKtsCkBwU7xI=
+github.com/longhorn/go-spdk-helper v0.9.1-0.20260828012436-4ec507083142 h1:UjcSekzUXjujX4N/5GPAnxESwltV4D4Ud9P35OLlvR8=
+github.com/longhorn/go-spdk-helper v0.9.1-0.20260828012436-4ec507083142/go.mod h1:r9Yrw5Pi/tIOPUIU4auCGcKIOfQG3cv7XAzR+4zrnyc=
 github.com/longhorn/types v0.0.0-20260814104707-529643438923 h1:Zvsu1JrjCuyk15diqGt3GM5WsZF4pdwKHygIZe45xnQ=
 github.com/longhorn/types v0.0.0-20260814104707-529643438923/go.mod h1:fmaMw+kNcCfoil6w9VNlEmXzBWIpZpofb2FvmxQFA8A=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/types/bdev.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/types/bdev.go
@@ -76,8 +76,7 @@ type BdevInfoBasic struct {
 	SupportedIoTypes SupportedIoTypes `json:"supported_io_types"`
 
 	MemoryDomains []struct {
-		DmaDeviceID   string `json:"dma_device_id"`
-		DmaDeviceType int32  `json:"dma_device_type"`
+		DmaDeviceType string `json:"dma_device_type"`
 	} `json:"memory_domains,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -129,7 +129,7 @@ github.com/longhorn/go-common-libs/sync
 github.com/longhorn/go-common-libs/sys
 github.com/longhorn/go-common-libs/types
 github.com/longhorn/go-common-libs/utils
-# github.com/longhorn/go-spdk-helper v0.9.1-0.20260814082531-318b4a23bb34
+# github.com/longhorn/go-spdk-helper v0.9.1-0.20260828012436-4ec507083142
 ## explicit; go 1.25.10
 github.com/longhorn/go-spdk-helper/pkg/initiator
 github.com/longhorn/go-spdk-helper/pkg/jsonrpc


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13834

#### What this PR does / why we need it:

SPDK v26.05 (longhorn-v26.05) writes memory_domains[].dma_device_type as a string instead of an int32 in the bdev_get_bdevs output, which broke decoding in go-spdk-helper and caused failures on common paths such as snapshot revert.

Vendor the updated go-spdk-helper that changes the BdevInfoBasic DmaDeviceType field type from int32 to string.

#### Special notes for your reviewer:

#### Additional documentation or context
