### PR TITLE
fix: keep the failure reason of a v2 block disk across a retried creation

### DIFF
--- a/pkg/spdk/disk.go
+++ b/pkg/spdk/disk.go
@@ -76,6 +76,12 @@ func (d *Disk) GetState() DiskState {
 	return d.State
 }
 
+func (d *Disk) GetErrorMsg() string {
+	d.RLock()
+	defer d.RUnlock()
+	return d.ErrorMsg
+}
+
 func NewDisk(diskName, diskUUID, diskPath, diskDriver string, blockSize int64) *Disk {
 	// DiskDriver is intentionally left unset: it holds the resolved driver, which
 	// is only known once DiskCreate has translated the requested one.

--- a/pkg/spdk/disk_test.go
+++ b/pkg/spdk/disk_test.go
@@ -1,0 +1,44 @@
+package spdk
+
+import (
+	"context"
+
+	. "gopkg.in/check.v1"
+
+	spdkrpc "github.com/longhorn/types/pkg/generated/spdkrpc"
+)
+
+// TestDiskCreateRetryKeepsPreviousErrorMsg covers longhorn/longhorn#13893: a retried
+// creation restarts from the creating state and can wait behind the disk creation
+// lock for several monitoring cycles, so DiskGet has to keep reporting the previous
+// reason instead of an empty message.
+func (s *TestSuite) TestDiskCreateRetryKeepsPreviousErrorMsg(c *C) {
+	const (
+		diskName = "test-disk"
+		diskPath = "0000:05:00.0"
+		errorMsg = "failed to get disk driver: device is not driven by the kernel"
+	)
+
+	failed := NewDisk(diskName, "test-uuid", diskPath, "", 4096)
+	failed.State = DiskStateError
+	failed.ErrorMsg = errorMsg
+
+	server := &Server{diskMap: map[string]*Disk{diskName: failed}}
+
+	_, err := server.DiskCreate(context.Background(), &spdkrpc.DiskCreateRequest{
+		DiskName: diskName,
+		DiskUuid: "test-uuid",
+		DiskPath: diskPath,
+	})
+	c.Assert(err, IsNil)
+
+	retried := server.diskMap[diskName]
+	c.Assert(retried, Not(Equals), failed)
+	c.Assert(retried.GetState(), Equals, DiskStateCreating)
+	c.Assert(retried.GetErrorMsg(), Equals, errorMsg)
+
+	disk, err := retried.DiskGet(nil, diskName, diskPath, "")
+	c.Assert(err, IsNil)
+	c.Assert(disk.State, Equals, string(DiskStateCreating))
+	c.Assert(disk.Message, Equals, errorMsg)
+}

--- a/pkg/spdk/server_disk.go
+++ b/pkg/spdk/server_disk.go
@@ -20,6 +20,7 @@ func (s *Server) DiskCreate(ctx context.Context, req *spdkrpc.DiskCreateRequest)
 	spdkClient := s.spdkClient
 
 	disk, exists := s.diskMap[req.DiskName]
+	previousErrorMsg := ""
 	if exists {
 		state := disk.GetState()
 		if state == DiskStateReady {
@@ -35,10 +36,15 @@ func (s *Server) DiskCreate(ctx context.Context, req *spdkrpc.DiskCreateRequest)
 		}
 		// A previous attempt failed. Retry instead of latching on the error state
 		// forever, so the disk can recover once the underlying issue is resolved.
+		previousErrorMsg = disk.GetErrorMsg()
 		logrus.Warnf("Retrying the creation of disk %s(%s) path %s after a previous failure", req.DiskName, req.DiskUuid, req.DiskPath)
 	}
 
 	disk = NewDisk(req.DiskName, req.DiskUuid, req.DiskPath, req.DiskDriver, req.BlockSize)
+	// The retry starts over from the creating state and can wait behind the disk
+	// creation lock for several monitoring cycles, so keep reporting the previous
+	// reason until this attempt reaches a conclusion.
+	disk.ErrorMsg = previousErrorMsg
 	s.diskMap[req.DiskName] = disk
 	s.Unlock()
 


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13893

#### What this PR does / why we need it:


Retrying a failed creation replaces the Disk record so that no resolved value of the previous attempt, such as the disk ID, the driver or the sizes, survives into the new one. That also dropped ErrorMsg, which is not per-attempt state but the diagnostic history the caller relies on.

The retry then starts over in the creating state and only afterwards queues for the disk creation lock, which serializes the creation of every disk on the node. While it waits, DiskGet reports the creating state with an empty message, so a caller polling periodically loses the reason of the failure and reports a generic message instead. Once several disks are created at the same time, for instance after a node reboot, the wait spans multiple polls.

Carry ErrorMsg over to the new record so the previous reason is still reported until the retry reaches a conclusion. It is overwritten on a failure and cleared on a success, so a healthy disk never keeps a stale reason.


#### Special notes for your reviewer:

#### Additional documentation or context
