### PR TITLE
fix(frontend): disconnect superseded NVMe-TCP path

### DIFF
--- a/pkg/spdk/enginefrontend.go
+++ b/pkg/spdk/enginefrontend.go
@@ -19,8 +19,10 @@ import (
 	"github.com/longhorn/types/pkg/generated/spdkrpc"
 
 	commonbitmap "github.com/longhorn/go-common-libs/bitmap"
+	commontypes "github.com/longhorn/go-common-libs/types"
 	spdkclient "github.com/longhorn/go-spdk-helper/pkg/spdk/client"
 	helpertypes "github.com/longhorn/go-spdk-helper/pkg/types"
+	helperutil "github.com/longhorn/go-spdk-helper/pkg/util"
 
 	"github.com/longhorn/longhorn-spdk-engine/pkg/client"
 	"github.com/longhorn/longhorn-spdk-engine/pkg/types"
@@ -97,6 +99,8 @@ type EngineFrontend struct {
 	setRemoteEngineTargetANAStateFn func(targetIP, engineName string, anaState NvmeTCPANAState) error
 	// Test hook for waiting for an NVMe-TCP controller to reach live state.
 	waitForNvmeTCPControllerLiveFn func(transportAddress string, transportPort int32) error
+	// Test hook for dropping a superseded NVMe-TCP path after a switchover.
+	disconnectStaleNvmeTCPPathFn func(nqn, transportAddress, transportServiceID string) error
 
 	// metadataDir is the base path for persisting engine frontend records.
 	// If empty, persistence is disabled.
@@ -1812,21 +1816,24 @@ func (ef *EngineFrontend) SwitchOverTarget(spdkClient *spdkclient.Client, newEng
 			"targetPort":    targetPort,
 		}).Info("Switched over engine frontend target")
 
-		// Do NOT explicitly disconnect the old controller path. Removing it
-		// immediately can race with the kernel processing the ANA state
-		// change on the new path — if the kernel hasn't fully switched to
-		// the new optimized path when the old controller is yanked, a brief
-		// "no available path" window causes I/O errors that make ext4 go
-		// read-only. Instead, let the kernel handle the stale controller
-		// through ctrl-loss-tmo. The old path's ANA is already set to
-		// "inaccessible" so no I/O will route through it.
-
 		// Persist updated record AFTER successful switchover.
 		ef.RLock()
 		if err := saveEngineFrontendRecord(ef.metadataDir, ef); err != nil {
 			ef.log.WithError(err).Warn("Failed to persist engine frontend record after switchover")
 		}
 		ef.RUnlock()
+
+		// Drop the superseded path. Removing it any earlier races with the
+		// kernel processing the ANA change on the new path, leaving a brief
+		// "no available path" window that makes ext4 go read-only; by here the
+		// new controller is live and the old path is already inaccessible.
+		// Leaving it to ctrl-loss-tmo instead keeps a controller retrying a
+		// dead target, whose partition-scan I/O errors read as a failing disk.
+		//
+		// Ordered after persistence, matching the phased path: a crash in
+		// between then leaves a correct record plus a stale path the kernel
+		// reaps, rather than a record naming a target whose path is gone.
+		ef.dropSupersededNvmeTCPPath(oldNQN, oldTargetIP, oldTargetPort, targetIP, targetPort)
 
 		return nil
 
@@ -2148,6 +2155,10 @@ func (ef *EngineFrontend) switchOverTargetBlockdevPhased(phase SwitchoverPhase, 
 		}
 		ef.RUnlock()
 
+		// New path is live and promoted, old path went inaccessible in the
+		// switching phase, so the superseded path can now be dropped.
+		ef.dropSupersededNvmeTCPPath(oldNQN, oldTargetIP, oldTargetPort, newTargetIP, newTargetPort)
+
 		ef.log.WithFields(logrus.Fields{
 			"oldEngineName": oldEngineName,
 			"engineName":    newEngineName,
@@ -2170,6 +2181,58 @@ func (ef *EngineFrontend) connectNvmeTCPPath(transportAddress string, transportP
 		return errors.Wrapf(ErrSwitchOverTargetInternal, "initiator is nil for engine frontend %s", ef.Name)
 	}
 	return ef.initiator.ConnectNVMeTCPPath(transportAddress, transportServiceID)
+}
+
+// disconnectStaleNvmeTCPPath removes one superseded NVMe-TCP path.
+//
+// The NQN is volume-scoped (see getVolumeTargetIdentity), so old and new
+// targets are paths of the SAME subsystem: DisconnectTarget would tear down
+// both, while DisconnectController matches on NQN + address and removes only
+// this one. It is a no-op if no controller matches.
+//
+// Callers MUST invoke this only after the new path is live and promoted, so no
+// I/O can route through the path being removed.
+func (ef *EngineFrontend) disconnectStaleNvmeTCPPath(nqn, transportAddress string, transportPort int32) error {
+	transportServiceID := strconv.Itoa(int(transportPort))
+	if ef.disconnectStaleNvmeTCPPathFn != nil {
+		return ef.disconnectStaleNvmeTCPPathFn(nqn, transportAddress, transportServiceID)
+	}
+
+	executor, err := helperutil.NewExecutor(commontypes.ProcDirectory)
+	if err != nil {
+		return errors.Wrap(err, "failed to create executor for stale NVMe-TCP path disconnect")
+	}
+
+	return initiator.DisconnectController(nqn, transportAddress, transportServiceID, executor)
+}
+
+// dropSupersededNvmeTCPPath best-effort removes the old path after a completed
+// switchover. Failure is swallowed: the volume is already served by the new
+// path, and the kernel still reaps the stale controller via ctrl-loss-tmo.
+func (ef *EngineFrontend) dropSupersededNvmeTCPPath(nqn, oldTargetIP string, oldTargetPort int32, newTargetIP string, newTargetPort int32) {
+	// Both addresses must be well formed. A malformed new address cannot be
+	// compared against the old one, and treating that mismatch as a superseded
+	// path would drop the path still serving the volume.
+	if nqn == "" || oldTargetIP == "" || oldTargetPort == 0 || newTargetIP == "" || newTargetPort == 0 {
+		return
+	}
+	// Same address (e.g. an engine rename in place): no superseded path, and
+	// dropping the only path would strand the volume.
+	if oldTargetIP == newTargetIP && oldTargetPort == newTargetPort {
+		return
+	}
+
+	log := ef.log.WithFields(logrus.Fields{
+		"nqn":           nqn,
+		"oldTargetIP":   oldTargetIP,
+		"oldTargetPort": oldTargetPort,
+	})
+	if err := ef.disconnectStaleNvmeTCPPath(nqn, oldTargetIP, oldTargetPort); err != nil {
+		log.WithError(err).Warn("Failed to disconnect superseded NVMe-TCP path; " +
+			"leaving it for the kernel to reap via ctrl-loss-tmo")
+		return
+	}
+	log.Info("Disconnected superseded NVMe-TCP path after switchover")
 }
 
 func (ef *EngineFrontend) reconnectNvmeTCPPath(transportAddress string, transportPort int32) error {

--- a/pkg/spdk/switchover_test.go
+++ b/pkg/spdk/switchover_test.go
@@ -1192,3 +1192,122 @@ func (s *TestSuite) TestIsSubsystemNotFoundError(c *C) {
 	c.Assert(isSubsystemNotFoundError(fmt.Errorf("something else: unable to find subsystem with NQN abc")), Equals, true)
 	c.Assert(isSubsystemNotFoundError(fmt.Errorf("connection refused")), Equals, false)
 }
+
+// newBlockdevSwitchoverFrontend builds a running blockdev EngineFrontend at
+// 10.0.0.1:2000 with remote interactions stubbed, so a switchover can be driven
+// without SPDK or a live NVMe target.
+func newBlockdevSwitchoverFrontend(c *C, updateCh chan interface{}) *EngineFrontend {
+	ef := NewEngineFrontend("ef-a", "engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 1024, 0, 0, updateCh, nil)
+	ef.State = lhtypes.InstanceStateRunning
+	ef.NvmeTcpFrontend.TargetIP = "10.0.0.1"
+	ef.NvmeTcpFrontend.TargetPort = 2000
+	ef.NvmeTcpFrontend.Nqn = getStableVolumeNQN("vol-a")
+	ef.NvmeTcpFrontend.Nguid = getStableVolumeNGUID("vol-a")
+	ef.Endpoint = "/dev/longhorn/vol-a"
+	ef.syncCurrentNVMeTCPPathLocked()
+	ef.initiator = &initiator.Initiator{
+		Endpoint:    ef.Endpoint,
+		NVMeTCPInfo: &initiator.NVMeTCPInfo{SubsystemNQN: ef.NvmeTcpFrontend.Nqn},
+	}
+	ef.getInitiatorEndpointFn = func() string { return "/dev/longhorn/vol-a" }
+	ef.loadInitiatorNVMeDeviceInfoFn = func(transportAddress, transportServiceID, subsystemNQN string) error { return nil }
+	ef.loadInitiatorEndpointFn = func(dmDeviceIsBusy bool) error { return nil }
+	ef.waitForNvmeTCPControllerLiveFn = func(transportAddress string, transportPort int32) error { return nil }
+	ef.connectNvmeTCPPathFn = func(transportAddress, transportServiceID string) error { return nil }
+	stubSwitchoverANASync(ef, nil)
+	return ef
+}
+
+func (s *TestSuite) TestEngineFrontendSwitchOverTargetBlockdevDropsSupersededPath(c *C) {
+	fmt.Println("Testing EngineFrontend.SwitchOverTarget drops the superseded NVMe-TCP path after switchover")
+
+	ef := newBlockdevSwitchoverFrontend(c, make(chan interface{}, 1))
+
+	var gotNQN, gotAddress, gotServiceID string
+	calls := 0
+	ef.disconnectStaleNvmeTCPPathFn = func(nqn, transportAddress, transportServiceID string) error {
+		calls++
+		gotNQN, gotAddress, gotServiceID = nqn, transportAddress, transportServiceID
+		return nil
+	}
+
+	err := ef.SwitchOverTarget(nil, "engine-b", "10.0.0.2:3000", "")
+	c.Assert(err, IsNil)
+
+	// Exactly the old path is dropped -- never the newly promoted one. Both
+	// share the volume-scoped NQN, so the address is what discriminates them.
+	c.Assert(calls, Equals, 1)
+	c.Assert(gotAddress, Equals, "10.0.0.1")
+	c.Assert(gotServiceID, Equals, "2000")
+	c.Assert(gotNQN, Equals, getStableVolumeNQN("vol-a"))
+
+	c.Assert(ef.NvmeTcpFrontend.TargetIP, Equals, "10.0.0.2")
+	c.Assert(ef.NvmeTcpFrontend.TargetPort, Equals, int32(3000))
+}
+
+func (s *TestSuite) TestEngineFrontendSwitchOverTargetBlockdevKeepsPathWhenAddressUnchanged(c *C) {
+	fmt.Println("Testing EngineFrontend.SwitchOverTarget does not drop the path when the target address is unchanged")
+
+	ef := newBlockdevSwitchoverFrontend(c, make(chan interface{}, 1))
+
+	calls := 0
+	ef.disconnectStaleNvmeTCPPathFn = func(nqn, transportAddress, transportServiceID string) error {
+		calls++
+		return nil
+	}
+
+	// Engine rename in place: dropping the only path would strand the volume.
+	err := ef.SwitchOverTarget(nil, "engine-b", "10.0.0.1:2000", "")
+	c.Assert(err, IsNil)
+	c.Assert(calls, Equals, 0)
+	c.Assert(ef.NvmeTcpFrontend.TargetIP, Equals, "10.0.0.1")
+	c.Assert(ef.NvmeTcpFrontend.TargetPort, Equals, int32(2000))
+}
+
+func (s *TestSuite) TestEngineFrontendSwitchOverTargetBlockdevDropFailureIsNonFatal(c *C) {
+	fmt.Println("Testing EngineFrontend.SwitchOverTarget survives a failure to drop the superseded path")
+
+	ef := newBlockdevSwitchoverFrontend(c, make(chan interface{}, 1))
+
+	calls := 0
+	ef.disconnectStaleNvmeTCPPathFn = func(nqn, transportAddress, transportServiceID string) error {
+		calls++
+		return fmt.Errorf("nvme disconnect failed")
+	}
+
+	// A failed cleanup must not fail the switchover.
+	err := ef.SwitchOverTarget(nil, "engine-b", "10.0.0.2:3000", "")
+	c.Assert(err, IsNil)
+	c.Assert(calls, Equals, 1)
+	c.Assert(ef.EngineName, Equals, "engine-b")
+	c.Assert(ef.NvmeTcpFrontend.TargetIP, Equals, "10.0.0.2")
+	c.Assert(ef.ErrorMsg, Equals, "")
+}
+
+func (s *TestSuite) TestDropSupersededNvmeTCPPathSkipsIncompleteInput(c *C) {
+	fmt.Println("Testing dropSupersededNvmeTCPPath skips incomplete or unchanged path input")
+
+	ef := NewEngineFrontend("ef-a", "engine-a", "vol-a", lhtypes.FrontendSPDKTCPBlockdev, 1024, 0, 0, make(chan interface{}, 1), nil)
+
+	calls := 0
+	ef.disconnectStaleNvmeTCPPathFn = func(nqn, transportAddress, transportServiceID string) error {
+		calls++
+		return nil
+	}
+
+	nqn := getStableVolumeNQN("vol-a")
+	ef.dropSupersededNvmeTCPPath("", "10.0.0.1", 2000, "10.0.0.2", 3000)  // no NQN
+	ef.dropSupersededNvmeTCPPath(nqn, "", 2000, "10.0.0.2", 3000)         // no old IP
+	ef.dropSupersededNvmeTCPPath(nqn, "10.0.0.1", 0, "10.0.0.2", 3000)    // no old port
+	ef.dropSupersededNvmeTCPPath(nqn, "10.0.0.1", 2000, "10.0.0.1", 2000) // unchanged address
+	// A malformed new address must not be read as a superseded old path: the
+	// old path is the one still serving the volume.
+	ef.dropSupersededNvmeTCPPath(nqn, "10.0.0.1", 2000, "", 3000)      // no new IP
+	ef.dropSupersededNvmeTCPPath(nqn, "10.0.0.1", 2000, "10.0.0.1", 0) // no new port, same IP
+	ef.dropSupersededNvmeTCPPath(nqn, "10.0.0.1", 2000, "10.0.0.2", 0) // no new port
+	c.Assert(calls, Equals, 0)
+
+	// Differing only by port is still a distinct path and must be dropped.
+	ef.dropSupersededNvmeTCPPath(nqn, "10.0.0.1", 2000, "10.0.0.1", 3000)
+	c.Assert(calls, Equals, 1)
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13938

#### What this PR does / why we need it:

A successful V2 blockdev frontend switchover currently leaves the old NVMe/TCP controller reconnecting until `ctrl-loss-tmo`. This can accumulate stale controllers and emit partition-scan I/O errors for a path that no longer serves active I/O.

After both monolithic and phased switchovers complete, disconnect the old controller by volume NQN, old IP, and old port. Cleanup runs only after the replacement controller is live, ANA promotion/demotion and endpoint reload have completed, and the new frontend state has been committed and persisted.

This uses `initiator.DisconnectController`, not `DisconnectTarget`: old and new paths share the same subsystem NQN, so NQN-wide cleanup would also remove the active path. Incomplete or unchanged addresses are skipped. Cleanup is best-effort; a disconnect failure is logged and the existing kernel `ctrl-loss-tmo` behavior remains the fallback.

#### Special notes for your reviewer:

This PR is intentionally draft pending live switchover validation with continuous I/O. The source patch has not yet been deployed to Meta production Longhorn volumes.

Original implementation and tests by Curtis Mewhort (@cmewhort-meta), ported upstream with the current constructor API.

#### Additional documentation or context

Focused tests cover:

- disconnecting exactly the old controller after successful switchover
- retaining the path for an unchanged address
- treating disconnect failure as non-fatal
- skipping incomplete addresses while treating a port-only change as distinct

Validation completed on the upstream port:

- `gofmt -l pkg/spdk`: clean
- `go vet ./pkg/spdk`: pass on Linux amd64
- `go test ./pkg/spdk -count=1`: pass on Linux amd64
- Linux amd64 and arm64 `go test -c ./pkg/spdk`: pass
- fork validation: https://github.com/christophersherman/longhorn-spdk-engine/actions/runs/33780523344

Integration validation required before Ready for Review:

1. Maintain continuous I/O to an attached V2 blockdev volume.
2. Perform a live target switchover.
3. Verify no I/O interruption, only the replacement controller remains, and the old controller does not enter a reconnect loop.
4. Inject a targeted-disconnect failure and verify switchover remains successful and `ctrl-loss-tmo` still provides fallback cleanup.
